### PR TITLE
Refactor/sqlite database migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ __pycache__/
 .coverage
 .ruff_cache/
 *.egg-info/
-data.json
+data.db
 uv.lock

--- a/app/config.py
+++ b/app/config.py
@@ -4,8 +4,12 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parent.parent
 
 
-def get_data_file_path() -> Path:
-	configured_path = os.getenv("MEMORIES_DATA_FILE")
+def get_database_file_path() -> Path:
+	configured_path = os.getenv("MEMORIES_DB_FILE") or os.getenv("MEMORIES_DATA_FILE")
 	if configured_path:
 		return Path(configured_path)
-	return ROOT_DIR / "data.json"
+	return ROOT_DIR / "data.db"
+
+
+def get_data_file_path() -> Path:
+	return get_database_file_path()

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,38 @@
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from app.config import get_database_file_path
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS memories (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	content TEXT NOT NULL,
+	tags TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	last_accessed_at TEXT,
+	memory_type TEXT NOT NULL,
+	status TEXT NOT NULL,
+	version INTEGER NOT NULL
+)
+"""
+
+
+def init_db() -> None:
+	database_file = get_database_file_path()
+	database_file.parent.mkdir(parents=True, exist_ok=True)
+	with sqlite3.connect(database_file) as connection:
+		connection.execute(SCHEMA_SQL)
+		connection.commit()
+
+
+@contextmanager
+def get_connection() -> Iterator[sqlite3.Connection]:
+	init_db()
+	connection = sqlite3.connect(get_database_file_path())
+	connection.row_factory = sqlite3.Row
+	try:
+		yield connection
+	finally:
+		connection.close()

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,7 +1,7 @@
 import json
 from datetime import UTC, datetime
 
-from app.config import get_data_file_path
+from app.db import get_connection
 from app.schemas import Memory, MemoryCreate, MemoryUpdate
 
 
@@ -9,37 +9,68 @@ def current_timestamp() -> str:
 	return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
-def find_next_id(data: list[dict]) -> int:
-	largest_id = 0
-	for item in data:
-		if item.get("id", 0) > largest_id:
-			largest_id = item["id"]
-	return largest_id + 1
+def _serialize_tags(tags: list[str]) -> str:
+	return json.dumps(tags)
 
 
-def load_data() -> list[dict]:
-	data_file = get_data_file_path()
-	try:
-		with data_file.open("r", encoding="utf-8") as file:
-			return json.load(file)
-	except FileNotFoundError:
-		return []
-	except json.JSONDecodeError:
-		return []
+def _row_to_memory(row) -> Memory:
+	return Memory(
+		id=row["id"],
+		content=row["content"],
+		tags=json.loads(row["tags"]),
+		created_at=row["created_at"],
+		updated_at=row["updated_at"],
+		last_accessed_at=row["last_accessed_at"],
+		memory_type=row["memory_type"],
+		status=row["status"],
+		version=row["version"],
+	)
 
 
-def save_data(data: list[dict]) -> None:
-	data_file = get_data_file_path()
-	data_file.parent.mkdir(parents=True, exist_ok=True)
-	with data_file.open("w", encoding="utf-8") as file:
-		json.dump(data, file)
+def _fetch_memory_row(connection, memory_id: int):
+	return connection.execute(
+		"""
+		SELECT id, content, tags, created_at, updated_at, last_accessed_at, memory_type, status, version
+		FROM memories
+		WHERE id = ?
+		""",
+		(memory_id,),
+	).fetchone()
 
 
 def create_memory(memory: MemoryCreate) -> Memory:
-	data = load_data()
 	timestamp = current_timestamp()
-	new_memory = Memory(
-		id=find_next_id(data),
+	with get_connection() as connection:
+		cursor = connection.execute(
+			"""
+			INSERT INTO memories (
+				content,
+				tags,
+				created_at,
+				updated_at,
+				last_accessed_at,
+				memory_type,
+				status,
+				version
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			""",
+			(
+				memory.content,
+				_serialize_tags(memory.tags),
+				timestamp,
+				timestamp,
+				None,
+				memory.memory_type,
+				memory.status,
+				1,
+			),
+		)
+		connection.commit()
+		memory_id = cursor.lastrowid
+
+	return Memory(
+		id=memory_id,
 		content=memory.content,
 		tags=memory.tags,
 		created_at=timestamp,
@@ -49,97 +80,146 @@ def create_memory(memory: MemoryCreate) -> Memory:
 		status=memory.status,
 		version=1,
 	)
-	data.append(new_memory.model_dump())
-	save_data(data)
-	return new_memory
 
 
 def create_memory_batch(memories: list[MemoryCreate]) -> list[Memory]:
-	data = load_data()
 	created_memories: list[Memory] = []
-	next_id = find_next_id(data)
+	with get_connection() as connection:
+		for memory in memories:
+			timestamp = current_timestamp()
+			cursor = connection.execute(
+				"""
+				INSERT INTO memories (
+					content,
+					tags,
+					created_at,
+					updated_at,
+					last_accessed_at,
+					memory_type,
+					status,
+					version
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+				(
+					memory.content,
+					_serialize_tags(memory.tags),
+					timestamp,
+					timestamp,
+					None,
+					memory.memory_type,
+					memory.status,
+					1,
+				),
+			)
+			created_memories.append(
+				Memory(
+					id=cursor.lastrowid,
+					content=memory.content,
+					tags=memory.tags,
+					created_at=timestamp,
+					updated_at=timestamp,
+					last_accessed_at=None,
+					memory_type=memory.memory_type,
+					status=memory.status,
+					version=1,
+				)
+			)
+		connection.commit()
 
-	for memory in memories:
-		timestamp = current_timestamp()
-		new_memory = Memory(
-			id=next_id,
-			content=memory.content,
-			tags=memory.tags,
-			created_at=timestamp,
-			updated_at=timestamp,
-			last_accessed_at=None,
-			memory_type=memory.memory_type,
-			status=memory.status,
-			version=1,
-		)
-		data.append(new_memory.model_dump())
-		created_memories.append(new_memory)
-		next_id += 1
-
-	save_data(data)
 	return created_memories
 
 
 def get_memories() -> list[Memory]:
-	return [Memory(**item) for item in load_data()]
+	with get_connection() as connection:
+		rows = connection.execute(
+			"""
+			SELECT id, content, tags, created_at, updated_at, last_accessed_at, memory_type, status, version
+			FROM memories
+			ORDER BY id
+			"""
+		).fetchall()
+	return [_row_to_memory(row) for row in rows]
 
 
 def get_memory(memory_id: int) -> Memory | None:
-	data = load_data()
+	with get_connection() as connection:
+		row = _fetch_memory_row(connection, memory_id)
+		if row is None:
+			return None
 
-	for index, item in enumerate(data):
-		if item["id"] == memory_id:
-			item["last_accessed_at"] = current_timestamp()
-			memory = Memory(**item)
-			data[index] = memory.model_dump()
-			save_data(data)
-			return memory
-	return None
+		last_accessed_at = current_timestamp()
+		connection.execute(
+			"UPDATE memories SET last_accessed_at = ? WHERE id = ?",
+			(last_accessed_at, memory_id),
+		)
+		connection.commit()
+
+		memory = _row_to_memory(row)
+		return memory.model_copy(update={"last_accessed_at": last_accessed_at})
 
 
 def update_memory(memory_id: int, memory: MemoryUpdate) -> Memory | None:
-	data = load_data()
 	update_data = memory.model_dump(exclude_unset=True)
+	with get_connection() as connection:
+		row = _fetch_memory_row(connection, memory_id)
+		if row is None:
+			return None
 
-	for index, item in enumerate(data):
-		if item["id"] == memory_id:
-			has_changes = any(item.get(key) != value for key, value in update_data.items())
-			if not has_changes:
-				return Memory(**item)
+		existing_memory = _row_to_memory(row)
+		has_changes = any(
+			getattr(existing_memory, key) != value for key, value in update_data.items()
+		)
+		if not has_changes:
+			return existing_memory
 
-			item.update(update_data)
-			item["updated_at"] = current_timestamp()
-			item["version"] += 1
-			updated_memory = Memory(**item)
-			data[index] = updated_memory.model_dump()
-			save_data(data)
-			return updated_memory
+		updated_memory = existing_memory.model_copy(update=update_data)
+		updated_at = current_timestamp()
+		version = existing_memory.version + 1
+		connection.execute(
+			"""
+			UPDATE memories
+			SET content = ?, tags = ?, updated_at = ?, memory_type = ?, status = ?, version = ?
+			WHERE id = ?
+			""",
+			(
+				updated_memory.content,
+				_serialize_tags(updated_memory.tags),
+				updated_at,
+				updated_memory.memory_type,
+				updated_memory.status,
+				version,
+				memory_id,
+			),
+		)
+		connection.commit()
 
-	return None
+		return updated_memory.model_copy(update={"updated_at": updated_at, "version": version})
 
 
 def delete_memory(memory_id: int) -> Memory | None:
-	data = load_data()
+	with get_connection() as connection:
+		row = _fetch_memory_row(connection, memory_id)
+		if row is None:
+			return None
 
-	for index, item in enumerate(data):
-		if item["id"] == memory_id:
-			deleted_memory = Memory(**item)
-			data.pop(index)
-			save_data(data)
-			return deleted_memory
-
-	return None
+		deleted_memory = _row_to_memory(row)
+		connection.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
+		connection.commit()
+		return deleted_memory
 
 
 def search_memories(query: str) -> list[Memory]:
 	query_lower = query.lower()
-	results: list[Memory] = []
-
-	for item in load_data():
-		memory = Memory(**item)
-		content_match = query_lower in memory.content.lower()
-		tags_match = any(query_lower in tag.lower() for tag in memory.tags)
-		if content_match or tags_match:
-			results.append(memory)
-
-	return results
+	query_pattern = f"%{query_lower}%"
+	with get_connection() as connection:
+		rows = connection.execute(
+			"""
+			SELECT id, content, tags, created_at, updated_at, last_accessed_at, memory_type, status, version
+			FROM memories
+			WHERE LOWER(content) LIKE ? OR LOWER(tags) LIKE ?
+			ORDER BY id
+			""",
+			(query_pattern, query_pattern),
+		).fetchall()
+	return [_row_to_memory(row) for row in rows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "memories-api"
 version = "0.1.0"
-description = "A small FastAPI project for storing memories with tags in a JSON database."
+description = "A small FastAPI project for storing memories with tags in a SQLite database."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ def client() -> TestClient:
 
 @pytest.fixture(autouse=True)
 def data_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-	file_path = tmp_path / "data.json"
-	file_path.write_text("[]", encoding="utf-8")
+	file_path = tmp_path / "data.db"
 	monkeypatch.setenv("MEMORIES_DATA_FILE", str(file_path))
 	return file_path

--- a/tests/helpers/database_helpers.py
+++ b/tests/helpers/database_helpers.py
@@ -1,6 +1,33 @@
 import json
+import sqlite3
 from pathlib import Path
 
 
 def read_database(data_file: Path) -> list[dict]:
-	return json.loads(data_file.read_text(encoding="utf-8"))
+	if not data_file.exists():
+		return []
+
+	with sqlite3.connect(data_file) as connection:
+		connection.row_factory = sqlite3.Row
+		rows = connection.execute(
+			"""
+			SELECT id, content, tags, created_at, updated_at, last_accessed_at, memory_type, status, version
+			FROM memories
+			ORDER BY id
+			"""
+		).fetchall()
+
+	return [
+		{
+			"id": row["id"],
+			"content": row["content"],
+			"tags": json.loads(row["tags"]),
+			"created_at": row["created_at"],
+			"updated_at": row["updated_at"],
+			"last_accessed_at": row["last_accessed_at"],
+			"memory_type": row["memory_type"],
+			"status": row["status"],
+			"version": row["version"],
+		}
+		for row in rows
+	]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,16 +1,25 @@
 from pathlib import Path
 
-from app.config import ROOT_DIR, get_data_file_path
+from app.config import ROOT_DIR, get_database_file_path
 
 
-def test_get_data_file_path_uses_env_override(monkeypatch):
-	configured_path = Path("C:/tmp/custom-memories.json")
+def test_get_database_file_path_uses_env_override(monkeypatch):
+	configured_path = Path("C:/tmp/custom-memories.db")
+	monkeypatch.setenv("MEMORIES_DB_FILE", str(configured_path))
+
+	assert get_database_file_path() == configured_path
+
+
+def test_get_database_file_path_uses_legacy_env_override(monkeypatch):
+	configured_path = Path("C:/tmp/legacy-memories.db")
+	monkeypatch.delenv("MEMORIES_DB_FILE", raising=False)
 	monkeypatch.setenv("MEMORIES_DATA_FILE", str(configured_path))
 
-	assert get_data_file_path() == configured_path
+	assert get_database_file_path() == configured_path
 
 
-def test_get_data_file_path_uses_default_repo_path(monkeypatch):
+def test_get_database_file_path_uses_default_repo_path(monkeypatch):
+	monkeypatch.delenv("MEMORIES_DB_FILE", raising=False)
 	monkeypatch.delenv("MEMORIES_DATA_FILE", raising=False)
 
-	assert get_data_file_path() == ROOT_DIR / "data.json"
+	assert get_database_file_path() == ROOT_DIR / "data.db"

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,66 +1,37 @@
-import json
-
-from app.schemas import MemoryUpdate
-from app.storage import find_next_id, search_memories, update_memory
+from app.schemas import MemoryCreate, MemoryUpdate
+from app.storage import create_memory, search_memories, update_memory
 
 
-def test_find_next_id_returns_next_largest_id():
-	data = [{"id": 1}, {"id": 4}, {"id": 2}]
+def test_create_memory_assigns_incrementing_ids():
+	first = create_memory(MemoryCreate(content="First memory", tags=["python"]))
+	second = create_memory(MemoryCreate(content="Second memory", tags=["sql"]))
 
-	assert find_next_id(data) == 5
+	assert first.id == 1
+	assert second.id == 2
 
 
 def test_search_memories_matches_content_and_tags_case_insensitively(monkeypatch):
-	data = [
-		{
-			"id": 1,
-			"content": "Learning FastAPI testing",
-			"tags": ["python", "api"],
-			"created_at": "2026-04-06T14:12:00.000000Z",
-			"updated_at": "2026-04-06T14:12:00.000000Z",
-			"last_accessed_at": None,
-			"memory_type": "fact",
-			"status": "active",
-			"version": 1,
-		},
-		{
-			"id": 2,
-			"content": "Database query notes",
-			"tags": ["SQL"],
-			"created_at": "2026-04-06T14:13:00.000000Z",
-			"updated_at": "2026-04-06T14:13:00.000000Z",
-			"last_accessed_at": None,
-			"memory_type": "task_context",
-			"status": "active",
-			"version": 1,
-		},
-	]
-
-	monkeypatch.setattr("app.storage.load_data", lambda: data)
+	create_memory(MemoryCreate(content="Learning FastAPI testing", tags=["python", "api"]))
+	create_memory(
+		MemoryCreate(
+			content="Database query notes",
+			tags=["SQL"],
+			memory_type="task_context",
+		)
+	)
 
 	results = search_memories("sql")
 
 	assert [memory.id for memory in results] == [2]
 
 
-def test_update_memory_returns_existing_memory_without_saving_on_no_op(monkeypatch):
-	stored_item = {
-		"id": 1,
-		"content": "Learning FastAPI testing",
-		"tags": ["python", "api"],
-		"created_at": "2026-04-06T14:12:00.000000Z",
-		"updated_at": "2026-04-06T14:12:00.000000Z",
-		"last_accessed_at": None,
-		"memory_type": "fact",
-		"status": "active",
-		"version": 1,
-	}
-	data = [stored_item.copy()]
-
-	monkeypatch.setattr("app.storage.load_data", lambda: data)
+def test_update_memory_returns_existing_memory_without_refreshing_timestamp(monkeypatch):
+	stored_item = create_memory(
+		MemoryCreate(content="Learning FastAPI testing", tags=["python", "api"])
+	)
 	monkeypatch.setattr(
-		"app.storage.save_data",
-		lambda _data: (_ for _ in ()).throw(AssertionError("save_data should not be called")),
+		"app.storage.current_timestamp",
+		lambda: (_ for _ in ()).throw(AssertionError("current_timestamp should not be called")),
 	)
 
 	result = update_memory(
@@ -69,30 +40,12 @@ def test_update_memory_returns_existing_memory_without_saving_on_no_op(monkeypat
 	)
 
 	assert result is not None
-	assert result.model_dump() == stored_item
+	assert result.model_dump() == stored_item.model_dump()
 
 
 def test_update_memory_persists_changes(monkeypatch):
-	stored_item = {
-		"id": 1,
-		"content": "Learning FastAPI testing",
-		"tags": ["python", "api"],
-		"created_at": "2026-04-06T14:12:00.000000Z",
-		"updated_at": "2026-04-06T14:12:00.000000Z",
-		"last_accessed_at": None,
-		"memory_type": "fact",
-		"status": "active",
-		"version": 1,
-	}
-	data = [stored_item.copy()]
-	saved_payloads: list[str] = []
-
-	monkeypatch.setattr("app.storage.load_data", lambda: data)
+	create_memory(MemoryCreate(content="Learning FastAPI testing", tags=["python", "api"]))
 	monkeypatch.setattr("app.storage.current_timestamp", lambda: "2026-04-06T14:30:00.000000Z")
-	monkeypatch.setattr(
-		"app.storage.save_data",
-		lambda payload: saved_payloads.append(json.dumps(payload, sort_keys=True)),
-	)
 
 	result = update_memory(1, MemoryUpdate(status="archived"))
 
@@ -100,4 +53,3 @@ def test_update_memory_persists_changes(monkeypatch):
 	assert result.status == "archived"
 	assert result.updated_at == "2026-04-06T14:30:00.000000Z"
 	assert result.version == 2
-	assert len(saved_payloads) == 1


### PR DESCRIPTION
# REFACTOR: SQLite Database Migration

## What

- Replace the JSON file-based persistence layer with SQLite-backed storage and centralized connection/schema setup in `db.py`
- Move memory CRUD and search operations onto SQL queries while preserving the existing API contract in `storage.py`
- Add database path configuration that prefers `MEMORIES_DB_FILE`, falls back to `MEMORIES_DATA_FILE`, and defaults to the repo-local `data.db` in `config.py`
- Update tests to run against isolated temporary SQLite databases and add coverage for the new config and storage behavior in `conftest.py`, `test_storage.py`, and `test_config.py`

## Why

- SQLite gives the project a more durable and realistic persistence layer without introducing external infrastructure.
- The change improves write safety and ID generation while keeping the HTTP and MCP surface area unchanged for clients.
- It also sets the project up for future query and schema evolution more cleanly than a single JSON file.

## Test Steps

- Used Postman to simulate HTTP requests and visualized the SQLite `data.db` file using the `SQLite Viewer` VS Code Extension
- `ruff format --check .`
- `ruff check .`
- `pytest`

## Other Notes

- The API shape is unchanged. Memories are still returned with the same fields and lifecycle metadata.
- Tags are stored as JSON text in SQLite and deserialized on read in `storage.py`
- Search remains case-insensitive across content and tags.
- Tests now isolate persistence per test run using a temporary database file in `conftest.py`
