### PR TITLE
Refactor/soft delete memories

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Behavior summary:
 - `created_at`, `updated_at`, `last_accessed_at`, and `version` are server-managed.
 - `POST /memories/batch` is all-or-nothing when validation fails.
 - `updated_at` and `version` change only when a PATCH request actually changes an editable field.
+- `DELETE /memories/{id}` performs a soft delete by setting `status` to `deleted`, refreshing `updated_at`, and incrementing `version`.
 - `last_accessed_at` is refreshed on `GET /memories/{id}`.
+- Soft-deleted memories are hidden from `GET /memories/{id}`.
 - Every memory returned by retrieval is also considered accessed, so `GET /memories` and MCP `query_memories_tool` refresh `last_accessed_at` only for the returned page.
+- Retrieval excludes soft-deleted memories by default unless `status=deleted` is requested explicitly.
 
 Allowed values:
 
@@ -233,6 +236,8 @@ Delete a memory:
 curl -X DELETE http://127.0.0.1:8000/memories/1
 ```
 
+This performs a soft delete. The row remains stored with `status="deleted"` and is hidden from normal single-record access and default retrieval.
+
 Example retrieval response:
 
 ```json
@@ -268,6 +273,8 @@ The MCP server exposes the same core memory operations over stdio:
 - `query_memories_tool`
 
 `query_memories_tool` mirrors the HTTP retrieval contract and accepts `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
+
+`delete_memory_tool` performs the same soft delete as `DELETE /memories/{id}` and marks the memory as `deleted` rather than removing the row physically.
 
 ## CI
 

--- a/app/storage.py
+++ b/app/storage.py
@@ -149,31 +149,28 @@ def create_memory_batch(memories: list[MemoryCreate]) -> list[Memory]:
 
 
 def _build_memory_filters(query: MemoryListQuery | None) -> tuple[str, list[object]]:
-	if query is None:
-		return "", []
-
 	clauses: list[str] = []
 	parameters: list[object] = []
 
-	if query.status is not None:
+	if query is None or query.status is None:
+		clauses.append("status != ?")
+		parameters.append("deleted")
+	else:
 		clauses.append("status = ?")
 		parameters.append(query.status)
 
-	if query.memory_type is not None:
+	if query is not None and query.memory_type is not None:
 		clauses.append("memory_type = ?")
 		parameters.append(query.memory_type)
 
-	if query.tag is not None:
+	if query is not None and query.tag is not None:
 		clauses.append("EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE json_each.value = ?)")
 		parameters.append(query.tag)
 
-	if query.q is not None:
+	if query is not None and query.q is not None:
 		query_pattern = f"%{query.q.lower()}%"
 		clauses.append("(LOWER(content) LIKE ? OR LOWER(tags) LIKE ?)")
 		parameters.extend([query_pattern, query_pattern])
-
-	if not clauses:
-		return "", parameters
 
 	return "WHERE " + " AND ".join(clauses), parameters
 

--- a/app/storage.py
+++ b/app/storage.py
@@ -45,6 +45,17 @@ def _fetch_memory_row(connection, memory_id: int):
 	).fetchone()
 
 
+def _fetch_visible_memory_row(connection, memory_id: int):
+	return connection.execute(
+		"""
+		SELECT id, content, tags, created_at, updated_at, last_accessed_at, memory_type, status, version
+		FROM memories
+		WHERE id = ? AND status != 'deleted'
+		""",
+		(memory_id,),
+	).fetchone()
+
+
 def create_memory(memory: MemoryCreate) -> Memory:
 	timestamp = current_timestamp()
 	with get_connection() as connection:
@@ -239,7 +250,7 @@ def refresh_memories_last_accessed(memories: list[Memory]) -> list[Memory]:
 
 def get_memory(memory_id: int) -> Memory | None:
 	with get_connection() as connection:
-		row = _fetch_memory_row(connection, memory_id)
+		row = _fetch_visible_memory_row(connection, memory_id)
 		if row is None:
 			return None
 
@@ -257,7 +268,7 @@ def get_memory(memory_id: int) -> Memory | None:
 def update_memory(memory_id: int, memory: MemoryUpdate) -> Memory | None:
 	update_data = memory.model_dump(exclude_unset=True)
 	with get_connection() as connection:
-		row = _fetch_memory_row(connection, memory_id)
+		row = _fetch_visible_memory_row(connection, memory_id)
 		if row is None:
 			return None
 
@@ -294,11 +305,22 @@ def update_memory(memory_id: int, memory: MemoryUpdate) -> Memory | None:
 
 def delete_memory(memory_id: int) -> Memory | None:
 	with get_connection() as connection:
-		row = _fetch_memory_row(connection, memory_id)
+		row = _fetch_visible_memory_row(connection, memory_id)
 		if row is None:
 			return None
 
-		deleted_memory = _row_to_memory(row)
-		connection.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
+		existing_memory = _row_to_memory(row)
+		updated_at = current_timestamp()
+		version = existing_memory.version + 1
+		connection.execute(
+			"""
+			UPDATE memories
+			SET status = ?, updated_at = ?, version = ?
+			WHERE id = ?
+			""",
+			("deleted", updated_at, version, memory_id),
+		)
 		connection.commit()
-		return deleted_memory
+		return existing_memory.model_copy(
+			update={"status": "deleted", "updated_at": updated_at, "version": version}
+		)

--- a/docs/data_object_schema.md
+++ b/docs/data_object_schema.md
@@ -236,7 +236,7 @@ You need a way to retire or disable memories without losing record history.
 - **`archived`**: memory is kept for history but should rarely be surfaced
 - **`superseded`**: replaced by a newer memory
 - **`invalid`**: determined to be wrong or unsafe to use
-- **`deleted`**: logically removed from normal operations
+- **`deleted`**: soft-deleted by the delete operation, hidden from single-record reads, and excluded from retrieval unless `status=deleted` is requested
 
 ### Recommendation
 At minimum support `active`, `superseded`, and `invalid`. Add `archived` and `deleted` if lifecycle control matters in your system.
@@ -298,6 +298,7 @@ Both surfaces return the same envelope:
 ## Filter semantics
 
 - `status` and `memory_type` are exact structured filters.
+- Retrieval excludes `status=deleted` by default unless the caller explicitly requests `status=deleted`.
 - `tag` is exact matching against the stored tag list.
 - `q` is case-insensitive free-text matching over `content` and stored tags.
 - Filters compose with `AND`.

--- a/tests/contract/test_mcp_contract.py
+++ b/tests/contract/test_mcp_contract.py
@@ -76,3 +76,33 @@ def test_delete_memory_tool_raises_value_error_when_missing(monkeypatch):
 
 	with pytest.raises(ValueError, match="Memory 7 not found"):
 		delete_memory_tool(7)
+
+
+def test_delete_memory_tool_returns_soft_deleted_memory(monkeypatch):
+	deleted_memory = Memory(
+		id=7,
+		content="Unsafe note",
+		tags=["safety"],
+		created_at="2026-04-06T14:12:00.000000Z",
+		updated_at="2026-04-06T14:20:00.000000Z",
+		last_accessed_at=None,
+		memory_type="fact",
+		status="deleted",
+		version=2,
+	)
+
+	monkeypatch.setattr("app.mcp_server.delete_memory", lambda memory_id: deleted_memory)
+
+	result = delete_memory_tool(7)
+
+	assert result == {
+		"id": 7,
+		"content": "Unsafe note",
+		"tags": ["safety"],
+		"created_at": "2026-04-06T14:12:00.000000Z",
+		"updated_at": "2026-04-06T14:20:00.000000Z",
+		"last_accessed_at": None,
+		"memory_type": "fact",
+		"status": "deleted",
+		"version": 2,
+	}

--- a/tests/integration/test_memories_delete.py
+++ b/tests/integration/test_memories_delete.py
@@ -12,20 +12,25 @@ def test_delete_memory_by_id_returns_deleted_memory_with_full_shape(
 ):
 	"""
 	Testing if a DELETE request to the /memories/{id} endpoint returns the
-	deleted memory with the full shape.
+	soft-deleted memory with the full shape.
 	Including:
 	- `created_at`
 	- `updated_at`
 	- `last_accessed_at`
-	fields and removes it from the database.
+	fields while keeping the row in the database.
 
 	Args:
 		client (TestClient): The TestClient for making requests to the FastAPI app.
 		data_file (Path): The Path for accessing the test database file.
 		monkeypatch: The MonkeyPatch for modifying attributes during tests.
 	"""
-	timestamp = "2026-04-06T14:12:00.000000Z"
-	monkeypatch.setattr(storage, "current_timestamp", lambda: timestamp)
+	timestamps = iter(
+		[
+			"2026-04-06T14:12:00.000000Z",
+			"2026-04-06T14:20:00.000000Z",
+		]
+	)
+	monkeypatch.setattr(storage, "current_timestamp", lambda: next(timestamps))
 
 	create_response = client.post(
 		"/memories",
@@ -42,14 +47,16 @@ def test_delete_memory_by_id_returns_deleted_memory_with_full_shape(
 		1,
 		"Learning FastAPI testing",
 		["python", "api"],
-		created_at=timestamp,
-		updated_at=timestamp,
+		created_at="2026-04-06T14:12:00.000000Z",
+		updated_at="2026-04-06T14:20:00.000000Z",
 		last_accessed_at=None,
+		status="deleted",
+		version=2,
 	)
 
 	assert response.status_code == 200
 	assert response.json() == expected
-	assert read_database(data_file) == []
+	assert read_database(data_file) == [expected]
 
 
 def test_delete_memory_by_id_not_found_returns_404(client: TestClient, data_file: Path):

--- a/tests/integration/test_memories_detail.py
+++ b/tests/integration/test_memories_detail.py
@@ -66,3 +66,44 @@ def test_get_memory_by_id_not_found_returns_404(client: TestClient, data_file: P
 	assert response.status_code == 404
 	assert response.json() == {"detail": "Memory not found"}
 	assert read_database(data_file) == []
+
+
+def test_get_memory_by_id_returns_404_for_soft_deleted_memory(
+	client: TestClient, data_file: Path, monkeypatch
+):
+	timestamps = iter(
+		[
+			"2026-04-06T14:12:00.000000Z",
+			"2026-04-06T14:20:00.000000Z",
+		]
+	)
+	monkeypatch.setattr(storage, "current_timestamp", lambda: next(timestamps))
+
+	create_response = client.post(
+		"/memories",
+		json={
+			"content": "Learning FastAPI testing",
+			"tags": ["python", "api"],
+		},
+	)
+	assert create_response.status_code == 200
+
+	delete_response = client.delete("/memories/1")
+	assert delete_response.status_code == 200
+
+	response = client.get("/memories/1")
+
+	assert response.status_code == 404
+	assert response.json() == {"detail": "Memory not found"}
+	assert read_database(data_file) == [
+		expected_memory(
+			1,
+			"Learning FastAPI testing",
+			["python", "api"],
+			created_at="2026-04-06T14:12:00.000000Z",
+			updated_at="2026-04-06T14:20:00.000000Z",
+			last_accessed_at=None,
+			status="deleted",
+			version=2,
+		)
+	]

--- a/tests/integration/test_memories_list.py
+++ b/tests/integration/test_memories_list.py
@@ -29,6 +29,128 @@ def test_get_memories_empty_returns_paginated_response(client: TestClient, data_
 	assert read_database(data_file) == []
 
 
+def test_get_memories_excludes_deleted_memories_by_default(
+	client: TestClient, data_file: Path, monkeypatch
+):
+	timestamps = iter(
+		[
+			"2026-04-06T14:12:00.000000Z",
+			"2026-04-06T14:13:00.000000Z",
+			"2026-04-06T14:20:00.000000Z",
+			"2026-04-06T14:30:00.000000Z",
+		]
+	)
+	monkeypatch.setattr(storage, "current_timestamp", lambda: next(timestamps))
+
+	client.post(
+		"/memories",
+		json={
+			"content": "Keep me",
+			"tags": ["active"],
+		},
+	)
+	client.post(
+		"/memories",
+		json={
+			"content": "Delete me",
+			"tags": ["deleted"],
+		},
+	)
+
+	delete_response = client.delete("/memories/2")
+	assert delete_response.status_code == 200
+
+	response = client.get("/memories")
+
+	expected_items = [
+		expected_memory(
+			1,
+			"Keep me",
+			["active"],
+			created_at="2026-04-06T14:12:00.000000Z",
+			updated_at="2026-04-06T14:12:00.000000Z",
+			last_accessed_at="2026-04-06T14:30:00.000000Z",
+		)
+	]
+
+	assert response.status_code == 200
+	assert response.json() == _expected_page(items=expected_items, total=1)
+	assert read_database(data_file) == [
+		expected_items[0],
+		expected_memory(
+			2,
+			"Delete me",
+			["deleted"],
+			created_at="2026-04-06T14:13:00.000000Z",
+			updated_at="2026-04-06T14:20:00.000000Z",
+			last_accessed_at=None,
+			status="deleted",
+			version=2,
+		),
+	]
+
+
+def test_get_memories_can_filter_explicitly_for_deleted_memories(
+	client: TestClient, data_file: Path, monkeypatch
+):
+	timestamps = iter(
+		[
+			"2026-04-06T14:12:00.000000Z",
+			"2026-04-06T14:13:00.000000Z",
+			"2026-04-06T14:20:00.000000Z",
+			"2026-04-06T14:30:00.000000Z",
+		]
+	)
+	monkeypatch.setattr(storage, "current_timestamp", lambda: next(timestamps))
+
+	client.post(
+		"/memories",
+		json={
+			"content": "Keep me",
+			"tags": ["active"],
+		},
+	)
+	client.post(
+		"/memories",
+		json={
+			"content": "Delete me",
+			"tags": ["deleted"],
+		},
+	)
+
+	delete_response = client.delete("/memories/2")
+	assert delete_response.status_code == 200
+
+	response = client.get("/memories", params={"status": "deleted"})
+
+	expected_items = [
+		expected_memory(
+			2,
+			"Delete me",
+			["deleted"],
+			created_at="2026-04-06T14:13:00.000000Z",
+			updated_at="2026-04-06T14:20:00.000000Z",
+			last_accessed_at="2026-04-06T14:30:00.000000Z",
+			status="deleted",
+			version=2,
+		)
+	]
+
+	assert response.status_code == 200
+	assert response.json() == _expected_page(items=expected_items, total=1)
+	assert read_database(data_file) == [
+		expected_memory(
+			1,
+			"Keep me",
+			["active"],
+			created_at="2026-04-06T14:12:00.000000Z",
+			updated_at="2026-04-06T14:12:00.000000Z",
+			last_accessed_at=None,
+		),
+		expected_items[0],
+	]
+
+
 def test_get_memories_returns_paginated_shape_and_updates_last_accessed_at(
 	client: TestClient, data_file: Path, monkeypatch
 ):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -61,6 +61,17 @@ def test_get_memories_applies_structured_filters_with_exact_tag_matching():
 	assert [memory.id for memory in results] == [1]
 
 
+def test_get_memories_excludes_deleted_by_default_but_allows_explicit_deleted_filter():
+	create_memory(MemoryCreate(content="Visible memory", tags=["active"]))
+	create_memory(MemoryCreate(content="Hidden memory", tags=["deleted"], status="deleted"))
+
+	default_results = get_memories()
+	deleted_results = get_memories(MemoryListQuery(status="deleted"))
+
+	assert [memory.id for memory in default_results] == [1]
+	assert [memory.id for memory in deleted_results] == [2]
+
+
 def test_get_memories_page_sorts_by_created_at_with_stable_id_tiebreaker(monkeypatch):
 	timestamps = iter(
 		[


### PR DESCRIPTION
# Soft Deleting Memories

## Related Links

**Personal Experience:** While using this MCP server through Claude Desktop on Windows 11, I noticed that deleting a memory removed it from the database entirely instead of using the existing `deleted` lifecycle state. For an agent-managed memory system, hard delete felt too destructive. This change moves deletion to a soft delete model so memories can be hidden from normal access without being physically removed.

## What

- Replaced hard delete behavior with soft delete behavior
- `DELETE /memories/{id}` now:
  - sets `status` to `deleted`
  - updates `updated_at`
  - increments `version`
- Changed single-record access so soft-deleted memories are treated as not found
  - `GET /memories/{id}` returns `404` for deleted memories
- Changed retrieval behavior so deleted memories are excluded by default
  - `GET /memories`
  - MCP `query_memories_tool`
- Preserved access to deleted memories only through an explicit status filter
  - `GET /memories?status=deleted`
  - MCP queries with `status="deleted"`
- Updated documentation in the README and schema docs to reflect the new behavior

## Why

- Reduces the risk of irreversible deletion during agent-driven memory management
- Preserves history for auditing, recovery, and future analysis
- Brings runtime behavior in line with the existing memory lifecycle model, which already supports a `deleted` status
- Makes deletion safer without removing the ability to inspect deleted memories when needed

## How

- Replaced physical row deletion with a status-based soft delete in storage
- Updated single-record reads and updates to hide deleted memories from normal operations
- Updated shared retrieval filtering so deleted memories are excluded unless explicitly requested
- Added and updated tests first to define the new HTTP and MCP contract
- Updated docs to describe soft delete semantics and deleted-memory retrieval

## Test Steps

### HTTP flow

1. Start the API server against a fresh database.
2. Create 3 memories with `POST /memories`.
3. Delete 1 or 2 of them with `DELETE /memories/{id}`.
4. Confirm the delete response returns the memory with:
   - `status: "deleted"`
   - a newer `updated_at`
   - an incremented `version`
5. Request `GET /memories/{deleted_id}`.
6. Confirm it returns `404`.
7. Request `GET /memories`.
8. Confirm the deleted memories are not included.
9. Request `GET /memories?status=deleted`.
10. Confirm the soft-deleted memories are returned and still exist in storage.

### MCP flow

1. Start the MCP server against a fresh database.
2. Create a few memories with `create_memory_tool`.
3. Soft delete one with `delete_memory_tool`.
4. Confirm the returned object has:
   - `status: "deleted"`
   - a newer `updated_at`
   - an incremented `version`
5. Query memories normally with `query_memories_tool`.
6. Confirm deleted memories are excluded by default.
7. Query again with `status="deleted"`.
8. Confirm the deleted memories are returned.

### Automated validation

Run the focused test coverage for this change:

```bash
pytest test_memories_delete.py -q
pytest test_memories_detail.py -q
pytest test_memories_list.py -q
pytest test_mcp_contract.py -q
pytest test_storage.py -q
```

Optional full regression:

```bash
pytest test.py -q
```