### PR TITLE
Feature/streamable http config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 *.egg-info/
 data.db
 uv.lock
+mcp_browser_clients.local.json

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ pyproject.toml
 This project is intended for single-user, local-only use on a trusted machine.
 
 - The HTTP API and MCP server do not implement application-level authentication or authorization.
-- The MCP server is intended to be used locally over stdio by a local MCP client.
-- The HTTP API should only be bound to localhost for local development.
+- The HTTP API and MCP streamable HTTP endpoint should only be bound to localhost for local development.
+- Browser-based MCP access is denied by default unless you create a local browser client allowlist file.
+- Browser origins are matched exactly. A configured origin of `http://localhost:3000` does not also allow `http://127.0.0.1:3000`.
 - Do not expose this service to the internet, a LAN, a shared VM, or any untrusted environment.
 - Do not run it behind a reverse proxy or with host binding such as `0.0.0.0` unless you add proper authentication, authorization, and transport security.
 - Treat the SQLite database file and local MCP/client configuration as sensitive local data.
@@ -130,18 +131,63 @@ pip install .
 ### Run the API
 
 ```powershell
-uvicorn app.main:app --reload
+uvicorn app.main:app --host 127.0.0.1 --port 8000 --reload
 ```
 
-Interactive docs are available at `http://localhost:8000/docs`.
+Interactive docs are available at `http://127.0.0.1:8000/docs`.
+
+This single app serves both surfaces:
+
+- REST API at `http://127.0.0.1:8000/memories`
+- MCP streamable HTTP endpoint at `http://127.0.0.1:8000/mcp`
+
+### Configure browser-based MCP clients
+
+The repo includes a committed example file:
+
+- `mcp_browser_clients.example.json`
+
+Create your real local override file in the repo root:
+
+- `mcp_browser_clients.local.json`
+
+That local override file is gitignored and is the only file read by the app for browser-origin allowlisting.
+
+If `mcp_browser_clients.local.json` does not exist, browser-based MCP access is denied by default, but the REST API and stdio MCP server still work.
+
+Example local file for Open WebUI running in the browser at `http://localhost:3000`:
+
+```json
+{
+	"browser_clients": [
+		{
+			"name": "open-webui-local",
+			"origin": "http://localhost:3000"
+		}
+	]
+}
+```
+
+If the local file exists but is invalid, the app logs a warning and denies browser-based MCP access instead of failing startup.
+
+### Open WebUI note
+
+For a local Open WebUI setup, two values matter:
+
+- Browser origin: usually `http://localhost:3000`. This is what goes into `mcp_browser_clients.local.json`.
+- MCP server URL: if Open WebUI runs in Docker, it may need `http://host.docker.internal:8000/mcp` instead of `http://localhost:8000/mcp` to reach the host machine.
 
 ### Use as an MCP Server
 
-This project can also run as a local MCP server over stdio.
+This project supports both MCP transports during local development:
 
-### MCP-Compatible Clients
+- Streamable HTTP through the mounted `/mcp` endpoint on the main FastAPI app
+- Stdio through the dedicated MCP entrypoint
+
+### Stdio MCP clients
 
 Add to your claude_desktop_config.json or mcp-config.json file:
+
 ```
 {
   "mcpServers": {
@@ -156,6 +202,22 @@ Add to your claude_desktop_config.json or mcp-config.json file:
   }
 }
 ```
+
+### Streamable HTTP MCP clients
+
+Point the client at:
+
+```text
+http://127.0.0.1:8000/mcp
+```
+
+If the client application runs in Docker on the same machine, use the host-reachable URL that the container can resolve, for example:
+
+```text
+http://host.docker.internal:8000/mcp
+```
+
+Browser-based clients still need an exact allowed origin in `mcp_browser_clients.local.json`.
 
 ### Manual Start
 
@@ -264,7 +326,7 @@ Example retrieval response:
 
 ## MCP tools
 
-The MCP server exposes the same core memory operations over stdio:
+The MCP server exposes the same core memory operations over stdio and streamable HTTP:
 
 - `create_memory_tool`
 - `update_memory_tool`

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,67 @@
+import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
+MCP_BROWSER_CLIENTS_EXAMPLE_FILE = ROOT_DIR / "mcp_browser_clients.example.json"
+MCP_BROWSER_CLIENTS_LOCAL_FILE = ROOT_DIR / "mcp_browser_clients.local.json"
+
+
+@dataclass(frozen=True)
+class BrowserClientConfig:
+	allowed_origins: list[str]
+	warnings: list[str]
+
+
+def load_browser_client_config() -> BrowserClientConfig:
+	if not MCP_BROWSER_CLIENTS_LOCAL_FILE.exists():
+		return BrowserClientConfig(allowed_origins=[], warnings=[])
+
+	warnings: list[str] = []
+
+	try:
+		config_data = json.loads(MCP_BROWSER_CLIENTS_LOCAL_FILE.read_text(encoding="utf-8"))
+	except (OSError, json.JSONDecodeError) as exc:
+		warnings.append(
+			f"Failed to load browser client config from {MCP_BROWSER_CLIENTS_LOCAL_FILE}: {exc}"
+		)
+		return BrowserClientConfig(allowed_origins=[], warnings=warnings)
+
+	if not isinstance(config_data, dict):
+		warnings.append(
+			f"Browser client config at {MCP_BROWSER_CLIENTS_LOCAL_FILE} must be a JSON object."
+		)
+		return BrowserClientConfig(allowed_origins=[], warnings=warnings)
+
+	browser_clients = config_data.get("browser_clients", [])
+	if not isinstance(browser_clients, list):
+		warnings.append(
+			f"Browser client config at {MCP_BROWSER_CLIENTS_LOCAL_FILE} must define browser_clients as a list."
+		)
+		return BrowserClientConfig(allowed_origins=[], warnings=warnings)
+
+	allowed_origins: list[str] = []
+	for index, browser_client in enumerate(browser_clients):
+		if not isinstance(browser_client, dict):
+			warnings.append(
+				f"Ignoring browser_clients[{index}] in {MCP_BROWSER_CLIENTS_LOCAL_FILE} because it is not an object."
+			)
+			continue
+
+		origin = browser_client.get("origin")
+		if not isinstance(origin, str) or not origin:
+			warnings.append(
+				f"Ignoring browser_clients[{index}] in {MCP_BROWSER_CLIENTS_LOCAL_FILE} because origin is missing or invalid."
+			)
+			continue
+
+		allowed_origins.append(origin)
+
+	if warnings:
+		return BrowserClientConfig(allowed_origins=[], warnings=warnings)
+
+	return BrowserClientConfig(allowed_origins=allowed_origins, warnings=[])
 
 
 def get_database_file_path() -> Path:

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,13 @@
+import logging
 from contextlib import asynccontextmanager
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
 
+from app.config import load_browser_client_config
 from app.mcp_server import mcp
 from app.schemas import (
 	Memory,
@@ -21,14 +26,42 @@ from app.storage import (
 	update_memory,
 )
 
+logger = logging.getLogger(__name__)
+browser_client_config = load_browser_client_config()
+
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
+	for warning_message in browser_client_config.warnings:
+		logger.warning(warning_message)
+
 	async with mcp.session_manager.run():
 		yield
 
 
 app = FastAPI(title="Memories API", lifespan=lifespan)
+app.add_middleware(
+	CORSMiddleware,
+	allow_origins=browser_client_config.allowed_origins,
+	allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+	allow_headers=[
+		"Content-Type",
+		"Accept",
+		"MCP-Protocol-Version",
+		"Mcp-Session-Id",
+	],
+	expose_headers=["Mcp-Session-Id"],
+)
+
+
+@app.middleware("http")
+async def validate_mcp_browser_origin(request: Request, call_next):
+	origin = request.headers.get("origin")
+	if request.url.path.startswith("/mcp") and origin is not None:
+		if origin not in browser_client_config.allowed_origins:
+			return JSONResponse(status_code=403, content={"detail": "Origin not allowed"})
+
+	return await call_next(request)
 
 
 @app.post("/memories")

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
+from contextlib import asynccontextmanager
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, HTTPException
 
+from app.mcp_server import mcp
 from app.schemas import (
 	Memory,
 	MemoryCreate,
@@ -19,7 +21,14 @@ from app.storage import (
 	update_memory,
 )
 
-app = FastAPI(title="Memories API")
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+	async with mcp.session_manager.run():
+		yield
+
+
+app = FastAPI(title="Memories API", lifespan=lifespan)
 
 
 @app.post("/memories")
@@ -68,3 +77,6 @@ def delete_memory_by_id(memory_id: int) -> Memory:
 	if deleted_memory is None:
 		raise HTTPException(status_code=404, detail="Memory not found")
 	return deleted_memory
+
+
+app.mount("/mcp", mcp.streamable_http_app())

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -10,7 +10,12 @@ from app.storage import (
 	update_memory,
 )
 
-mcp = FastMCP("memories-api")
+mcp = FastMCP(
+	"memories-api",
+	stateless_http=True,
+	json_response=True,
+	streamable_http_path="/",
+)
 
 
 def serialize_memory(memory) -> dict:
@@ -119,9 +124,13 @@ def read_memory(memory_id: int) -> dict:
 	return serialize_memory(memory)
 
 
-def run() -> None:
+def run_stdio() -> None:
 	mcp.run()
 
 
+def run() -> None:
+	run_stdio()
+
+
 if __name__ == "__main__":
-	run()
+	run_stdio()

--- a/mcp_browser_clients.example.json
+++ b/mcp_browser_clients.example.json
@@ -1,0 +1,8 @@
+{
+	"browser_clients": [
+		{
+			"name": "open-webui-local",
+			"origin": "http://localhost:3000"
+		}
+	]
+}

--- a/tests/contract/test_mcp_http_transport.py
+++ b/tests/contract/test_mcp_http_transport.py
@@ -1,0 +1,66 @@
+import importlib
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import app.main as main_module
+import app.mcp_server as mcp_server_module
+from app import config as config_module
+
+
+def build_client_with_browser_config(monkeypatch, tmp_path: Path, browser_clients: list[dict]):
+	config_path = tmp_path / "mcp_browser_clients.local.json"
+	config_path.write_text(json.dumps({"browser_clients": browser_clients}), encoding="utf-8")
+	monkeypatch.setattr(config_module, "MCP_BROWSER_CLIENTS_LOCAL_FILE", config_path)
+	importlib.reload(mcp_server_module)
+	reloaded_main = importlib.reload(main_module)
+	return TestClient(reloaded_main.app)
+
+
+def test_mcp_http_rejects_browser_requests_when_no_local_allowlist_exists(client: TestClient):
+	response = client.post(
+		"/mcp",
+		headers={"Origin": "http://localhost:3000"},
+		json={},
+	)
+
+	assert response.status_code == 403
+	assert response.json() == {"detail": "Origin not allowed"}
+
+
+def test_mcp_http_allows_configured_browser_origin(monkeypatch, tmp_path: Path):
+	with build_client_with_browser_config(
+		monkeypatch,
+		tmp_path,
+		[{"name": "open-webui-local", "origin": "http://localhost:3000"}],
+	) as client:
+		response = client.post(
+			"/mcp",
+			headers={"Origin": "http://localhost:3000"},
+			json={},
+		)
+
+	assert response.status_code != 403
+	assert response.status_code != 404
+
+
+def test_mcp_http_allows_mcp_request_headers_for_allowed_origin(monkeypatch, tmp_path: Path):
+	with build_client_with_browser_config(
+		monkeypatch,
+		tmp_path,
+		[{"name": "open-webui-local", "origin": "http://localhost:3000"}],
+	) as client:
+		response = client.options(
+			"/mcp",
+			headers={
+				"Origin": "http://localhost:3000",
+				"Access-Control-Request-Method": "POST",
+				"Access-Control-Request-Headers": "MCP-Protocol-Version,Mcp-Session-Id",
+			},
+		)
+
+	assert response.status_code == 200
+	assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+	assert "MCP-Protocol-Version" in response.headers["access-control-allow-headers"]
+	assert "Mcp-Session-Id" in response.headers["access-control-allow-headers"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,11 @@
+import json
 from pathlib import Path
 
-from app.config import ROOT_DIR, get_database_file_path
+from app.config import (
+	ROOT_DIR,
+	get_database_file_path,
+	load_browser_client_config,
+)
 
 
 def test_get_database_file_path_uses_env_override(monkeypatch):
@@ -14,3 +19,56 @@ def test_get_database_file_path_uses_default_repo_path(monkeypatch):
 	monkeypatch.delenv("MEMORIES_DB_FILE", raising=False)
 
 	assert get_database_file_path() == ROOT_DIR / "data.db"
+
+
+def test_load_browser_client_config_denies_browser_access_when_local_file_is_missing(
+	monkeypatch, tmp_path: Path
+):
+	missing_config_path = tmp_path / "mcp_browser_clients.local.json"
+	monkeypatch.setattr("app.config.MCP_BROWSER_CLIENTS_LOCAL_FILE", missing_config_path)
+
+	config = load_browser_client_config()
+
+	assert config.allowed_origins == []
+	assert config.warnings == []
+
+
+def test_load_browser_client_config_warns_and_denies_when_json_is_invalid(
+	monkeypatch, tmp_path: Path
+):
+	config_path = tmp_path / "mcp_browser_clients.local.json"
+	config_path.write_text("{invalid json", encoding="utf-8")
+	monkeypatch.setattr("app.config.MCP_BROWSER_CLIENTS_LOCAL_FILE", config_path)
+
+	config = load_browser_client_config()
+
+	assert config.allowed_origins == []
+	assert len(config.warnings) == 1
+	assert str(config_path) in config.warnings[0]
+
+
+def test_load_browser_client_config_returns_exact_allowed_origins(monkeypatch, tmp_path: Path):
+	config_path = tmp_path / "mcp_browser_clients.local.json"
+	config_path.write_text(
+		json.dumps(
+			{
+				"browser_clients": [
+					{
+						"name": "open-webui-local",
+						"origin": "http://localhost:3000",
+					},
+					{
+						"name": "other-local-app",
+						"origin": "http://127.0.0.1:8080",
+					},
+				],
+			}
+		),
+		encoding="utf-8",
+	)
+	monkeypatch.setattr("app.config.MCP_BROWSER_CLIENTS_LOCAL_FILE", config_path)
+
+	config = load_browser_client_config()
+
+	assert config.allowed_origins == ["http://localhost:3000", "http://127.0.0.1:8080"]
+	assert config.warnings == []


### PR DESCRIPTION
# Streamable HTTP Config

## Related Links

**Context:** The long-term goal of this project is to provide a universal memory layer that can be reused across different chat applications rather than tying memory to a single client. Until now, the MCP server was primarily useful through stdio-based desktop integrations. Adding streamable HTTP moves the project in the right direction by making the same memory service accessible to chat applications that rely on HTTP MCP connections, while still preserving stdio support and keeping the current setup local-only for safety.

## What

- Mounted the MCP server into the existing FastAPI app while keeping stdio MCP support available
- Added local browser-origin allowlist config for browser-based MCP clients
- Restricted browser access to configured local origins
- Documented the combined REST + MCP local setup

## Why

- Supports MCP clients that require streamable HTTP
- Keeps local development strict and localhost-only
- Makes browser access opt-in and configurable per user
- Preserves stdio support for existing local MCP workflows

## How

- Configured the shared FastMCP server for streamable HTTP while preserving stdio as a separate execution path
- Mounted the FastMCP ASGI app into the existing FastAPI application so REST and MCP are served from one process
- Added FastAPI lifespan management to run the MCP session manager inside the main app
- Introduced a committed example browser-client config file plus a gitignored local override file for machine-specific origin allowlists
- Loaded browser-origin settings from config and applied them to both CORS middleware and explicit MCP origin validation
- Implemented a deny-by-default fallback so browser-based access is disabled when no local config is present
- Treated invalid local browser config as a warning condition that disables browser access without breaking REST or stdio usage
- Added focused tests for mounted MCP HTTP behavior, config loading, denied-origin behavior, and allowed-origin behavior
- Updated documentation to describe the combined app, local-only security model, Open WebUI Docker setup, and both MCP transport options

## Test Steps

- Ran full test suite: `pytest`
- Verified REST routes still work by running uvicorn locally and using Postman
- Verified mounted MCP endpoint is exposed at `/mcp`
- Verified browser requests are denied by default without a local allowlist
- Verified configured browser origins are allowed

## Other Notes

- Auth is still intentionally deferred for local-only development
- Local browser config remains gitignored
- Browser-origin matching is exact
- Streamable HTTP is intended for localhost-bound development only at this stage
