### PR TITLE
Refactor memories MCP tools for agent-friendly workflows

### DIFF
--- a/.github/skills/memories/SKILL.md
+++ b/.github/skills/memories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memories
-description: 'Use when working with the memories-api MCP server, query_memories_tool, create_memory_tool, update_memory_tool, delete_memory_tool, or read_memory. Guides recall, personalization, deduping, sensitive-memory confirmation, contradiction handling, and prompt/resource usage for this repo.'
+description: 'Use when working with the memories-api MCP server, bootstrap_memories_tool, query_memories_tool, create_memory_tool, update_memory_tool, delete_memory_tool, or read_memory. Guides recall, personalization, deduping, sensitive-memory confirmation, contradiction handling, and prompt/resource usage for this repo.'
 argument-hint: '[task or memory operation]'
 user-invocable: true
 ---
@@ -19,8 +19,8 @@ Use this skill when an agent is deciding how to interact with the memories API o
 ## Procedure
 
 1. Decide whether memory recall is actually needed for the task.
-2. At the beginning of a session, run two targeted bootstrap queries: active preferences first, then active identity memories.
-3. For a substantive reply, use one moderate query shaped by `memory_type`, `tag`, or focused `q` terms.
+2. At the beginning of a session, call `bootstrap_memories_tool` to load active preferences first, then active identity memories.
+3. For a substantive reply, use one moderate `query_memories_tool` call shaped by `memory_type`, `tag`, or focused `q` terms.
 4. If considering a write, check whether the information is durable, atomic, and safe to store.
 5. Ask before storing any sensitive memory.
 6. Prefer updating an existing memory over creating a duplicate when the match is clear.

--- a/.github/skills/memories/SKILL.md
+++ b/.github/skills/memories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memories
-description: 'Use when working with the memories-api MCP server, bootstrap_memories_tool, query_memories_tool, create_memory_tool, update_memory_tool, delete_memory_tool, or read_memory. Guides recall, personalization, deduping, sensitive-memory confirmation, contradiction handling, and prompt/resource usage for this repo.'
+description: 'Use when working with the memories-api MCP server, prime_memory_context, search_memories, record_memory, revise_memory, retire_memory, or inspect_memory. Guides recall, personalization, deduping, sensitive-memory confirmation, contradiction handling, and prompt/resource usage for this repo.'
 argument-hint: '[task or memory operation]'
 user-invocable: true
 ---
@@ -19,8 +19,8 @@ Use this skill when an agent is deciding how to interact with the memories API o
 ## Procedure
 
 1. Decide whether memory recall is actually needed for the task.
-2. At the beginning of a session, call `bootstrap_memories_tool` to load active preferences first, then active identity memories.
-3. For a substantive reply, use one moderate `query_memories_tool` call shaped by `memory_type`, `tag`, or focused `q` terms.
+2. At the beginning of a session, call `prime_memory_context` to load active preferences first, then active identity memories.
+3. For a substantive reply, use one moderate `search_memories` call shaped by `memory_type`, `tag`, or focused `q` terms.
 4. If considering a write, check whether the information is durable, atomic, and safe to store.
 5. Ask before storing any sensitive memory.
 6. Prefer updating an existing memory over creating a duplicate when the match is clear.

--- a/.github/skills/memories/assets/use-memories-api-assistant.md
+++ b/.github/skills/memories/assets/use-memories-api-assistant.md
@@ -3,8 +3,8 @@ You have access to the memories-api MCP server.
 Use memories to improve personalization and continuity with narrow, deliberate tool usage.
 
 Behavior rules:
-- On bootstrap, recall active preference memories first, then active identity memories.
-- For a substantive reply, use at most one moderate query unless the user explicitly asks for deeper recall.
+- On bootstrap, call `bootstrap_memories_tool` once to recall active preference memories first, then active identity memories.
+- For follow-up recall, use `query_memories_tool` with at most one moderate query unless the user explicitly asks for deeper recall.
 - Prefer structured filters such as `memory_type`, `status`, and `tag` before relying on broad free-text matching.
 - Treat every returned memory as a read event that refreshes `last_accessed_at`.
 - Default to autonomous memory handling unless the user asks for a more cautious mode.
@@ -30,3 +30,5 @@ Transparency requirement:
 - Keep the summary brief and factual.
 - Include the action taken, the target memory id or ids when available, the memory type or tags when helpful, and a one-line reason for the action.
 - If no memory tool was used, do not add the summary.
+
+If this is part of the initial user message in this chat history, start with the bootstrap tool call now.

--- a/.github/skills/memories/assets/use-memories-api-assistant.md
+++ b/.github/skills/memories/assets/use-memories-api-assistant.md
@@ -3,8 +3,8 @@ You have access to the memories-api MCP server.
 Use memories to improve personalization and continuity with narrow, deliberate tool usage.
 
 Behavior rules:
-- On bootstrap, call `bootstrap_memories_tool` once to recall active preference memories first, then active identity memories.
-- For follow-up recall, use `query_memories_tool` with at most one moderate query unless the user explicitly asks for deeper recall.
+- On bootstrap, call `prime_memory_context` once to recall active preference memories first, then active identity memories.
+- For follow-up recall, use `search_memories` with at most one moderate query unless the user explicitly asks for deeper recall.
 - Prefer structured filters such as `memory_type`, `status`, and `tag` before relying on broad free-text matching.
 - Treat every returned memory as a read event that refreshes `last_accessed_at`.
 - Default to autonomous memory handling unless the user asks for a more cautious mode.

--- a/.github/skills/memories/assets/use-memories-api-assistant.md
+++ b/.github/skills/memories/assets/use-memories-api-assistant.md
@@ -4,7 +4,8 @@ Use memories to improve personalization and continuity with narrow, deliberate t
 
 Behavior rules:
 - On bootstrap, call `prime_memory_context` once to recall active preference memories first, then active identity memories.
-- For follow-up recall, use `search_memories` with at most one moderate query unless the user explicitly asks for deeper recall.
+- After bootstrap, proactively scan for memories relevant to the user's first message before responding. If the message mentions a person, event, date, or ongoing project, query for it immediately; don't ask the user to provide information that may already be stored
+- For follow-up recall, use `search_memories`. Start with a single broad keyword. If that returns nothing, retry with one alternative keyword before giving up. Never use multi-word phrases as your first query; single keywords cast a wider net.
 - Prefer structured filters such as `memory_type`, `status`, and `tag` before relying on broad free-text matching.
 - Treat every returned memory as a read event that refreshes `last_accessed_at`.
 - Default to autonomous memory handling unless the user asks for a more cautious mode.

--- a/.github/skills/memories/references/memories-query-recipes.md
+++ b/.github/skills/memories/references/memories-query-recipes.md
@@ -1,8 +1,10 @@
 # Query Recipes
 
-Use these recipes as starting points. Keep limits small unless the user explicitly asks for broader recall.
+Use these recipes as the canonical query shapes behind `bootstrap_memories_tool` and targeted `query_memories_tool` calls. Keep limits small unless the user explicitly asks for broader recall.
 
 ## Bootstrap Preference Recall
+
+This is the preference page returned by `bootstrap_memories_tool`.
 
 ```json
 {
@@ -15,6 +17,8 @@ Use these recipes as starting points. Keep limits small unless the user explicit
 ```
 
 ## Bootstrap Identity Recall
+
+This is the identity page returned by `bootstrap_memories_tool`.
 
 ```json
 {

--- a/.github/skills/memories/references/memories-query-recipes.md
+++ b/.github/skills/memories/references/memories-query-recipes.md
@@ -1,10 +1,10 @@
 # Query Recipes
 
-Use these recipes as the canonical query shapes behind `bootstrap_memories_tool` and targeted `query_memories_tool` calls. Keep limits small unless the user explicitly asks for broader recall.
+Use these recipes as the canonical query shapes behind `prime_memory_context` and targeted `search_memories` calls. Keep limits small unless the user explicitly asks for broader recall.
 
 ## Bootstrap Preference Recall
 
-This is the preference page returned by `bootstrap_memories_tool`.
+This is the preference page returned by `prime_memory_context`.
 
 ```json
 {
@@ -18,7 +18,7 @@ This is the preference page returned by `bootstrap_memories_tool`.
 
 ## Bootstrap Identity Recall
 
-This is the identity page returned by `bootstrap_memories_tool`.
+This is the identity page returned by `prime_memory_context`.
 
 ```json
 {
@@ -81,8 +81,8 @@ Use this workflow when the content may need `sensitive`, `pii`, or `health` tags
 
 Before creating a memory, check whether an existing active memory already captures the same durable fact or preference.
 
-- If the match is clear, use `update_memory_tool`.
-- If the new information is materially distinct, use `create_memory_tool`.
+- If the match is clear, use `revise_memory`.
+- If the new information is materially distinct, use `record_memory`.
 - If the overlap is uncertain, ask the user before writing.
 
 For sensitive memories, do the confirmation step before any create or update.
@@ -94,4 +94,4 @@ If a new statement conflicts with an existing memory:
 1. Read or query the existing memory narrowly.
 2. Explain the conflict to the user.
 3. Ask whether to correct the existing record or invalidate it.
-4. Apply `update_memory_tool` or `update_memory_tool(..., status="invalid")` only after confirmation.
+4. Apply `revise_memory` or `revise_memory(..., status="invalid")` only after confirmation.

--- a/.github/skills/memories/references/memories-tool-behavior-policy.md
+++ b/.github/skills/memories/references/memories-tool-behavior-policy.md
@@ -12,18 +12,15 @@ Use this policy when deciding how to query, read, create, update, or invalidate 
 
 ### Bootstrap recall
 
-At the beginning of a session, run two targeted queries:
+At the beginning of a session, call `bootstrap_memories_tool` once to retrieve active preferences and active identity memories in one read-only step.
 
-1. Active preferences with `memory_type=preference`, `status=active`, `sort=updated_at`, and a small `limit`.
-2. Active identity memories with `memory_type=identity`, `status=active`, `sort=updated_at`, and a small `limit`.
-
-Use `query_memories_tool` for these retrieval steps.
+Use `query_memories_tool` for any follow-up retrieval steps that need narrower or broader filtering than the bootstrap snapshot.
 
 Do not start with a broad catch-all query.
 
 ### Substantive reply recall
 
-For a reply that benefits from memory, use one moderate query shaped by the task.
+For a reply that benefits from memory, use multiple `query_memories_tool` calls shaped by the task.
 
 Preferred order:
 

--- a/.github/skills/memories/references/memories-tool-behavior-policy.md
+++ b/.github/skills/memories/references/memories-tool-behavior-policy.md
@@ -12,15 +12,15 @@ Use this policy when deciding how to query, read, create, update, or invalidate 
 
 ### Bootstrap recall
 
-At the beginning of a session, call `bootstrap_memories_tool` once to retrieve active preferences and active identity memories in one read-only step.
+At the beginning of a session, call `prime_memory_context` once to retrieve active preferences and active identity memories in one read-only step.
 
-Use `query_memories_tool` for any follow-up retrieval steps that need narrower or broader filtering than the bootstrap snapshot.
+Use `search_memories` for any follow-up retrieval steps that need narrower or broader filtering than the bootstrap snapshot.
 
 Do not start with a broad catch-all query.
 
 ### Substantive reply recall
 
-For a reply that benefits from memory, use multiple `query_memories_tool` calls shaped by the task.
+For a reply that benefits from memory, use multiple `search_memories` calls shaped by the task.
 
 Preferred order:
 
@@ -79,7 +79,7 @@ Recommended flow:
 5. If the information is materially distinct, create a new memory.
 6. If overlap or contradiction is uncertain, ask the user before writing.
 
-When the match is clear, prefer `update_memory_tool` over `create_memory_tool`.
+When the match is clear, prefer `revise_memory` over `record_memory`.
 Create a new memory only when the new information is materially distinct.
 
 ## Contradictions

--- a/.github/skills/memories/scripts/validate_memories_skill.py
+++ b/.github/skills/memories/scripts/validate_memories_skill.py
@@ -14,11 +14,12 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[4]
 
 EXPECTED_TOOL_SYMBOLS = [
-	"create_memory_tool",
-	"update_memory_tool",
-	"delete_memory_tool",
-	"read_memory",
-	"query_memories_tool",
+	"record_memory",
+	"revise_memory",
+	"retire_memory",
+	"inspect_memory",
+	"search_memories",
+	"prime_memory_context",
 ]
 
 EXPECTED_PROMPT_NAME = "use_memories_api"
@@ -51,9 +52,10 @@ def validate_prompt_and_resource_builders(mcp_server, failures: list[str]) -> No
 		failures,
 	)
 	record("# Query Recipes" in resource_text, "Resource contains query recipes heading", failures)
+	record("search_memories" in resource_text, "Resource mentions search_memories", failures)
 	record(
-		"query_memories_tool" in resource_text,
-		"Resource mentions query_memories_tool",
+		"prime_memory_context" in resource_text,
+		"Resource mentions prime_memory_context",
 		failures,
 	)
 
@@ -97,7 +99,7 @@ def validate_registered_surfaces(mcp_server, failures: list[str]) -> None:
 
 
 def validate_tool_workflow(mcp_server, failures: list[str]) -> None:
-	created = mcp_server.create_memory_tool(
+	created = mcp_server.record_memory(
 		content="User prefers concise answers",
 		tags=["preference", "writing-style"],
 		memory_type="preference",
@@ -106,7 +108,7 @@ def validate_tool_workflow(mcp_server, failures: list[str]) -> None:
 	record(created["status"] == "active", "Create tool returns an active memory", failures)
 	record(created["memory_type"] == "preference", "Create tool preserves memory_type", failures)
 
-	queried = mcp_server.query_memories_tool(
+	queried = mcp_server.search_memories(
 		status="active",
 		memory_type="preference",
 		tag="writing-style",
@@ -123,10 +125,10 @@ def validate_tool_workflow(mcp_server, failures: list[str]) -> None:
 		failures,
 	)
 
-	read_back = mcp_server.read_memory(memory_id)
+	read_back = mcp_server.inspect_memory(memory_id)
 	record(read_back["id"] == memory_id, "Read tool returns the created memory", failures)
 
-	updated = mcp_server.update_memory_tool(
+	updated = mcp_server.revise_memory(
 		memory_id,
 		content="User prefers concise technical answers",
 	)
@@ -136,10 +138,10 @@ def validate_tool_workflow(mcp_server, failures: list[str]) -> None:
 		failures,
 	)
 
-	deleted = mcp_server.delete_memory_tool(memory_id)
+	deleted = mcp_server.retire_memory(memory_id)
 	record(deleted["status"] == "deleted", "Delete tool performs a soft delete", failures)
 
-	deleted_page = mcp_server.query_memories_tool(status="deleted", limit=5, offset=0)
+	deleted_page = mcp_server.search_memories(status="deleted", limit=5, offset=0)
 	record(
 		deleted_page["total"] == 1,
 		"Deleted memories remain queryable by explicit status",
@@ -147,7 +149,7 @@ def validate_tool_workflow(mcp_server, failures: list[str]) -> None:
 	)
 
 	try:
-		mcp_server.read_memory(memory_id)
+		mcp_server.inspect_memory(memory_id)
 	except ValueError:
 		record(True, "Read tool hides deleted memories from normal reads", failures)
 	else:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Behavior summary:
 - `DELETE /memories/{id}` performs a soft delete by setting `status` to `deleted`, refreshing `updated_at`, and incrementing `version`.
 - `last_accessed_at` is refreshed on `GET /memories/{id}`.
 - Soft-deleted memories are hidden from `GET /memories/{id}`.
-- Every memory returned by retrieval is also considered accessed, so `GET /memories` and MCP `query_memories_tool` refresh `last_accessed_at` only for the returned page.
+- Every memory returned by retrieval is also considered accessed, so `GET /memories`, `query_memories_tool`, and `bootstrap_memories_tool` refresh `last_accessed_at` only for the returned items in each page.
 - Retrieval excludes soft-deleted memories by default unless `status=deleted` is requested explicitly.
 
 Allowed values:
@@ -43,7 +43,7 @@ Allowed values:
 Retrieval now flows through one contract on both surfaces:
 
 - HTTP uses `GET /memories`.
-- MCP uses `query_memories_tool`.
+- MCP uses `bootstrap_memories_tool` for the initial preference and identity snapshot, and `query_memories_tool` for targeted recall.
 - Both accept the same filters: `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
 - Both return the same envelope: `items`, `total`, `limit`, `offset`, and `has_more`.
 
@@ -120,12 +120,13 @@ This single app serves both surfaces:
 
 The MCP server exposes three surface types:
 
-- Tools for create, read, update, delete, and deterministic query flows
+- Tools for create, read, update, delete, deterministic query, and bootstrap flows
 - A static prompt named `use_memories_api` for deliberate memory-tool usage
 - A resource at `memories://policy/tool-behavior` with tool-behavior policy and query recipes
 
 The prompt and resource are meant to keep MCP clients and agents aligned on the same memory behavior:
 
+- Bootstrap should happen through `bootstrap_memories_tool` before any broader recall.
 - Default autonomy is `autonomous` for normal memory handling.
 - Agents should remain transparent and include a short `Memory actions:` summary whenever they use memory tools.
 - Sensitive memories tagged with `sensitive`, `pii`, or `health` require explicit user confirmation before storage.
@@ -307,7 +308,10 @@ The MCP server exposes the same core memory operations over stdio and streamable
 - `update_memory_tool`
 - `delete_memory_tool`
 - `read_memory`
+- `bootstrap_memories_tool`
 - `query_memories_tool`
+
+`bootstrap_memories_tool` returns the two startup recall pages in one call: active preferences and active identity memories.
 
 `query_memories_tool` mirrors the HTTP retrieval contract and accepts `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Behavior summary:
 - `DELETE /memories/{id}` performs a soft delete by setting `status` to `deleted`, refreshing `updated_at`, and incrementing `version`.
 - `last_accessed_at` is refreshed on `GET /memories/{id}`.
 - Soft-deleted memories are hidden from `GET /memories/{id}`.
-- Every memory returned by retrieval is also considered accessed, so `GET /memories`, `query_memories_tool`, and `bootstrap_memories_tool` refresh `last_accessed_at` only for the returned items in each page.
+- Every memory returned by retrieval is also considered accessed, so `GET /memories`, `search_memories`, and `prime_memory_context` refresh `last_accessed_at` only for the returned items in each page.
 - Retrieval excludes soft-deleted memories by default unless `status=deleted` is requested explicitly.
 
 Allowed values:
@@ -43,7 +43,7 @@ Allowed values:
 Retrieval now flows through one contract on both surfaces:
 
 - HTTP uses `GET /memories`.
-- MCP uses `bootstrap_memories_tool` for the initial preference and identity snapshot, and `query_memories_tool` for targeted recall.
+- MCP uses `prime_memory_context` for the initial preference and identity snapshot, and `search_memories` for targeted recall.
 - Both accept the same filters: `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
 - Both return the same envelope: `items`, `total`, `limit`, `offset`, and `has_more`.
 
@@ -120,13 +120,13 @@ This single app serves both surfaces:
 
 The MCP server exposes three surface types:
 
-- Tools for create, read, update, delete, deterministic query, and bootstrap flows
+- Tools for record, inspect, revise, retire, deterministic search, and bootstrap flows
 - A static prompt named `use_memories_api` for deliberate memory-tool usage
 - A resource at `memories://policy/tool-behavior` with tool-behavior policy and query recipes
 
 The prompt and resource are meant to keep MCP clients and agents aligned on the same memory behavior:
 
-- Bootstrap should happen through `bootstrap_memories_tool` before any broader recall.
+- Bootstrap should happen through `prime_memory_context` before any broader recall.
 - Default autonomy is `autonomous` for normal memory handling.
 - Agents should remain transparent and include a short `Memory actions:` summary whenever they use memory tools.
 - Sensitive memories tagged with `sensitive`, `pii`, or `health` require explicit user confirmation before storage.
@@ -304,18 +304,18 @@ Example retrieval response:
 
 The MCP server exposes the same core memory operations over stdio and streamable HTTP:
 
-- `create_memory_tool`
-- `update_memory_tool`
-- `delete_memory_tool`
-- `read_memory`
-- `bootstrap_memories_tool`
-- `query_memories_tool`
+- `record_memory`
+- `revise_memory`
+- `retire_memory`
+- `inspect_memory`
+- `prime_memory_context`
+- `search_memories`
 
-`bootstrap_memories_tool` returns the two startup recall pages in one call: active preferences and active identity memories.
+`prime_memory_context` returns the two startup recall pages in one call: active preferences and active identity memories.
 
-`query_memories_tool` mirrors the HTTP retrieval contract and accepts `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
+`search_memories` mirrors the HTTP retrieval contract and accepts `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
 
-`delete_memory_tool` performs the same soft delete as `DELETE /memories/{id}` and marks the memory as `deleted` rather than removing the row physically.
+`retire_memory` performs the same soft delete as `DELETE /memories/{id}` and marks the memory as `deleted` rather than removing the row physically.
 
 ## CI
 

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -64,12 +64,12 @@ def _build_memory_page_response(query: MemoryListQuery) -> dict:
 	).model_dump()
 
 
-def _build_bootstrap_partial_query(memory_type: str) -> MemoryListQuery:
+def _build_bootstrap_query(memory_type: str) -> MemoryListQuery:
 	return MemoryListQuery(
 		status="active",
 		memory_type=memory_type,
 		sort="updated_at",
-		limit=5,
+		limit=10,
 		offset=0,
 	)
 
@@ -95,15 +95,21 @@ def use_memories_api_prompt() -> list[AssistantMessage]:
 
 
 @mcp.tool(
-	description="Create a new memory. Use this to store new information that you want to remember. Make sure the content is concise and informative, and use tags to categorize the memory for easy retrieval later."
+	description="""Record a new durable memory when the user shares stable preference, identity,
+project, or workflow information that should be available later. Use this after you have
+decided the fact is worth keeping and you are not just capturing a one-off chat detail.
+Keep the content atomic and concise, choose short literal tags that aid retrieval, and
+confirm with the user before storing any sensitive material or anything that should be
+tagged with sensitive, pii, or health. The tool creates a new memory and returns the stored
+object so you can verify the content, tags, type, status, and server-managed metadata."""
 )
-def create_memory_tool(
+def record_memory(
 	content: str,
 	tags: list[str],
 	memory_type: str = "fact",
 	status: str = "active",
 ) -> dict:
-	"""Create a memory and return the stored object."""
+	"""Record a memory and return the stored object."""
 	memory = create_memory(
 		MemoryCreate(
 			content=content,
@@ -116,16 +122,22 @@ def create_memory_tool(
 
 
 @mcp.tool(
-	description="Update an existing memory. Use this to modify the content, tags, type, or status of a memory you have previously created."
+	description="""Revise an existing memory when you have already found the right record and
+the goal is to improve its wording, tags, type, or status without creating a duplicate.
+Use this when the new statement is the same durable fact or preference, or when the current
+record needs a small correction. Pass only the fields that actually need to change; omitted
+fields stay untouched. If the new information conflicts with the current record, stop and
+ask the user which version should remain authoritative before writing. The tool returns the
+updated record, including the new version and updated timestamp, so you can confirm the change."""
 )
-def update_memory_tool(
+def revise_memory(
 	memory_id: int,
 	content: str | None = None,
 	tags: list[str] | None = None,
 	memory_type: str | None = None,
 	status: str | None = None,
 ) -> dict:
-	"""Update editable fields on an existing memory."""
+	"""Revise editable fields on an existing memory."""
 	update_fields = {
 		"content": content,
 		"tags": tags,
@@ -142,10 +154,15 @@ def update_memory_tool(
 
 
 @mcp.tool(
-	description="Delete a memory by its ID. Use this to remove a memory you no longer need or find irrelevant/untrue."
+	description="""Retire a memory when it should no longer participate in normal recall but
+should remain auditable. This performs a soft delete by changing the status to deleted rather
+than removing the row, so it is safe for records that were stored in error, are no longer
+relevant, or should be removed from active use after user confirmation. Use this only after
+you have decided not to revise the memory instead. The tool returns the soft-deleted record
+so you can confirm the final status and version."""
 )
-def delete_memory_tool(memory_id: int) -> dict:
-	"""Delete a memory by id and return the removed object."""
+def retire_memory(memory_id: int) -> dict:
+	"""Retire a memory by id and return the soft-deleted object."""
 	memory = delete_memory(memory_id)
 	if memory is None:
 		raise ValueError(f"Memory {memory_id} not found")
@@ -153,9 +170,14 @@ def delete_memory_tool(memory_id: int) -> dict:
 
 
 @mcp.tool(
-	description="Query memories with optional filters, free-text matching, deterministic sorting, and pagination. Use this to retrieve memories by status, type, tag, or q and inspect the paginated result envelope."
+	description="""Search the memory store with deterministic filtering and pagination when you
+need targeted recall, deduping, or a follow-up read after bootstrap. Prefer structured
+filters first (status, memory_type, and tag) and add one word q values only when lexical narrowing is
+helpful. Use the smallest page that answers the question, because returned items are treated
+as accessed and their access timestamps are refreshed. The tool returns the standard paginated
+envelope with items, total, limit, offset, and has_more."""
 )
-def query_memories_tool(
+def search_memories(
 	status: str | None = None,
 	memory_type: str | None = None,
 	tag: str | None = None,
@@ -164,7 +186,7 @@ def query_memories_tool(
 	limit: int = 10,
 	offset: int = 0,
 ) -> dict:
-	"""Query memories using the same retrieval contract as the HTTP API."""
+	"""Search memories using the shared retrieval contract."""
 	query = MemoryListQuery(
 		status=status,
 		memory_type=memory_type,
@@ -177,11 +199,18 @@ def query_memories_tool(
 	return _build_memory_page_response(query)
 
 
-@mcp.tool(description="Bootstrap active preference and identity memories in one read-only call.")
-def bootstrap_memories_tool() -> dict:
-	"""Return the canonical bootstrap recall pages for preferences and identities."""
-	preference_query = _build_bootstrap_partial_query("preference")
-	identity_query = _build_bootstrap_partial_query("identity")
+@mcp.tool(
+	description="""Prime the working context at the start of a session or whenever you want the
+default memory snapshot before broader reasoning. This tool performs the two canonical
+startup recalls in one read-only call: active preferences and active identity memories, both
+using the shared retrieval contract and small pages. Use it before other search calls so the
+model can orient itself quickly without chaining two separate queries. The tool returns
+separate preference and identity envelopes, making the next step obvious."""
+)
+def prime_memory_context() -> dict:
+	"""Prime the working memory context with the startup snapshot."""
+	preference_query = _build_bootstrap_query("preference")
+	identity_query = _build_bootstrap_query("identity")
 
 	return {
 		"preferences": _build_memory_page_response(preference_query),
@@ -190,10 +219,14 @@ def bootstrap_memories_tool() -> dict:
 
 
 @mcp.tool(
-	description="Read a memory by its ID. Use this only when you know the ID of the memory you want to read."
+	description="""Inspect a specific memory when you already know the memory ID and need the
+full stored record. Use it for targeted verification, correction workflows, or a precise
+read where broader recall would be unnecessary. Do not use it as a substitute for search
+when you do not know which record matters. The tool returns the memory object and refreshes
+its access timestamp because the record was surfaced to the caller."""
 )
-def read_memory(memory_id: int) -> dict:
-	"""Return one memory by id."""
+def inspect_memory(memory_id: int) -> dict:
+	"""Inspect one memory by id and return the stored object."""
 	memory = get_memory(memory_id)
 	if memory is None:
 		raise ValueError(f"Memory {memory_id} not found")

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -51,6 +51,29 @@ def serialize_memory(memory) -> dict:
 	return memory.model_dump()
 
 
+def _build_memory_page_response(query: MemoryListQuery) -> dict:
+	paged_memories, total = get_memories_page(query)
+	items = refresh_memories_last_accessed(paged_memories)
+
+	return MemoryListResponse(
+		items=items,
+		total=total,
+		limit=query.limit,
+		offset=query.offset,
+		has_more=query.offset + len(items) < total,
+	).model_dump()
+
+
+def _build_bootstrap_partial_query(memory_type: str) -> MemoryListQuery:
+	return MemoryListQuery(
+		status="active",
+		memory_type=memory_type,
+		sort="updated_at",
+		limit=5,
+		offset=0,
+	)
+
+
 @mcp.resource(
 	"memories://policy/tool-behavior",
 	name="memories-tool-behavior-policy",
@@ -151,16 +174,19 @@ def query_memories_tool(
 		limit=limit,
 		offset=offset,
 	)
-	paged_memories, total = get_memories_page(query)
-	items = refresh_memories_last_accessed(paged_memories)
+	return _build_memory_page_response(query)
 
-	return MemoryListResponse(
-		items=items,
-		total=total,
-		limit=query.limit,
-		offset=query.offset,
-		has_more=query.offset + len(items) < total,
-	).model_dump()
+
+@mcp.tool(description="Bootstrap active preference and identity memories in one read-only call.")
+def bootstrap_memories_tool() -> dict:
+	"""Return the canonical bootstrap recall pages for preferences and identities."""
+	preference_query = _build_bootstrap_partial_query("preference")
+	identity_query = _build_bootstrap_partial_query("identity")
+
+	return {
+		"preferences": _build_memory_page_response(preference_query),
+		"identities": _build_memory_page_response(identity_query),
+	}
 
 
 @mcp.tool(

--- a/docs/data_object_schema.md
+++ b/docs/data_object_schema.md
@@ -257,7 +257,8 @@ In this project, `version` increments only when PATCH changes the record.
 This project uses one retrieval contract across HTTP and MCP.
 
 - HTTP: `GET /memories`
-- MCP: `query_memories_tool`
+- MCP bootstrap: `bootstrap_memories_tool`
+- MCP retrieval: `query_memories_tool`
 
 Both surfaces accept the same query fields:
 

--- a/docs/data_object_schema.md
+++ b/docs/data_object_schema.md
@@ -257,8 +257,8 @@ In this project, `version` increments only when PATCH changes the record.
 This project uses one retrieval contract across HTTP and MCP.
 
 - HTTP: `GET /memories`
-- MCP bootstrap: `bootstrap_memories_tool`
-- MCP retrieval: `query_memories_tool`
+- MCP bootstrap: `prime_memory_context`
+- MCP retrieval: `search_memories`
 
 Both surfaces accept the same query fields:
 

--- a/docs/mcp_prompt_skill_design.md
+++ b/docs/mcp_prompt_skill_design.md
@@ -28,7 +28,7 @@ The system is organized around a small set of consistent behaviors:
 
 The MCP prompt is the runtime entry point for agents that need a memory-aware posture. It is best used when an assistant is about to begin a task that may benefit from bootstrap recall, cautious writes, or contradiction handling.
 
-The prompt should point the model toward `bootstrap_memories_tool` for startup and `query_memories_tool` for follow-up recall instead of restating the entire behavior contract in every session.
+The prompt should point the model toward `prime_memory_context` for startup and `search_memories` for follow-up recall instead of restating the entire behavior contract in every session.
 
 The prompt is intentionally static and concise. It should point the model toward the shared policy rather than restating the entire behavior contract in every session. That keeps the runtime surface stable and reduces drift between prompt behavior and the policy files.
 

--- a/docs/mcp_prompt_skill_design.md
+++ b/docs/mcp_prompt_skill_design.md
@@ -20,13 +20,15 @@ The system is organized around a small set of consistent behaviors:
 | Surface | Purpose | Canonical file |
 | --- | --- | --- |
 | MCP prompt | Static assistant priming for memory-aware sessions | [use-memories-api-assistant.md](../.github/skills/memories/assets/use-memories-api-assistant.md) |
-| MCP resource | Canonical policy and query recipes served by the MCP server | [memories-tool-behavior-policy.md](../.github/skills/memories/references/memories-tool-behavior-policy.md), [memories-query-recipes.md](../.github/skills/memories/references/memories-query-recipes.md) |
+| MCP resource | Canonical policy, bootstrap guidance, and query recipes served by the MCP server | [memories-tool-behavior-policy.md](../.github/skills/memories/references/memories-tool-behavior-policy.md), [memories-query-recipes.md](../.github/skills/memories/references/memories-query-recipes.md) |
 | Repository skill | Workspace guidance for using and maintaining the memory workflow | [SKILL.md](../.github/skills/memories/SKILL.md) |
 | MCP wiring | FastMCP registration for the prompt and resource | [app/mcp_server.py](../app/mcp_server.py) |
 
 ## MCP prompt
 
-The MCP prompt is the runtime entry point for agents that need a memory-aware posture. It is best used when an assistant is about to begin a task that may benefit from recall, cautious writes, or contradiction handling.
+The MCP prompt is the runtime entry point for agents that need a memory-aware posture. It is best used when an assistant is about to begin a task that may benefit from bootstrap recall, cautious writes, or contradiction handling.
+
+The prompt should point the model toward `bootstrap_memories_tool` for startup and `query_memories_tool` for follow-up recall instead of restating the entire behavior contract in every session.
 
 The prompt is intentionally static and concise. It should point the model toward the shared policy rather than restating the entire behavior contract in every session. That keeps the runtime surface stable and reduces drift between prompt behavior and the policy files.
 

--- a/tests/contract/test_mcp_contract.py
+++ b/tests/contract/test_mcp_contract.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.mcp_server import delete_memory_tool, query_memories_tool
+from app.mcp_server import bootstrap_memories_tool, delete_memory_tool, query_memories_tool
 from app.schemas import Memory
 
 
@@ -68,6 +68,85 @@ def test_query_memories_tool_returns_paginated_response_from_shared_retrieval_pa
 		"limit": 1,
 		"offset": 1,
 		"has_more": True,
+	}
+
+
+def test_bootstrap_memories_tool_returns_two_shared_retrieval_pages(monkeypatch):
+	seen = []
+	preference_memory = Memory(
+		id=1,
+		content="Pref memory",
+		tags=["preference"],
+		created_at="2026-04-06T14:12:00.000000Z",
+		updated_at="2026-04-06T14:12:00.000000Z",
+		last_accessed_at=None,
+		memory_type="preference",
+		status="active",
+		version=1,
+	)
+	identity_memory = Memory(
+		id=2,
+		content="Identity memory",
+		tags=["identity"],
+		created_at="2026-04-06T14:12:00.000000Z",
+		updated_at="2026-04-06T14:12:00.000000Z",
+		last_accessed_at=None,
+		memory_type="identity",
+		status="active",
+		version=1,
+	)
+
+	def fake_get_memories_page(query):
+		seen.append(query.model_dump())
+		if query.memory_type == "preference":
+			return [preference_memory], 1
+		return [identity_memory], 1
+
+	def fake_refresh_memories_last_accessed(memories):
+		return memories
+
+	monkeypatch.setattr("app.mcp_server.get_memories_page", fake_get_memories_page)
+	monkeypatch.setattr(
+		"app.mcp_server.refresh_memories_last_accessed", fake_refresh_memories_last_accessed
+	)
+
+	result = bootstrap_memories_tool()
+
+	assert seen == [
+		{
+			"status": "active",
+			"memory_type": "preference",
+			"tag": None,
+			"q": None,
+			"sort": "updated_at",
+			"limit": 5,
+			"offset": 0,
+		},
+		{
+			"status": "active",
+			"memory_type": "identity",
+			"tag": None,
+			"q": None,
+			"sort": "updated_at",
+			"limit": 5,
+			"offset": 0,
+		},
+	]
+	assert result == {
+		"preferences": {
+			"items": [preference_memory.model_dump()],
+			"total": 1,
+			"limit": 5,
+			"offset": 0,
+			"has_more": False,
+		},
+		"identities": {
+			"items": [identity_memory.model_dump()],
+			"total": 1,
+			"limit": 5,
+			"offset": 0,
+			"has_more": False,
+		},
 	}
 
 

--- a/tests/contract/test_mcp_contract.py
+++ b/tests/contract/test_mcp_contract.py
@@ -1,10 +1,10 @@
 import pytest
 
-from app.mcp_server import bootstrap_memories_tool, delete_memory_tool, query_memories_tool
+from app.mcp_server import prime_memory_context, retire_memory, search_memories
 from app.schemas import Memory
 
 
-def test_query_memories_tool_returns_paginated_response_from_shared_retrieval_path(monkeypatch):
+def test_search_memories_returns_paginated_response_from_shared_retrieval_path(monkeypatch):
 	seen = {}
 	returned_memory = Memory(
 		id=1,
@@ -31,7 +31,7 @@ def test_query_memories_tool_returns_paginated_response_from_shared_retrieval_pa
 		lambda memories: [refreshed_memory],
 	)
 
-	result = query_memories_tool(
+	result = search_memories(
 		status="active",
 		memory_type="fact",
 		tag="python",
@@ -71,7 +71,7 @@ def test_query_memories_tool_returns_paginated_response_from_shared_retrieval_pa
 	}
 
 
-def test_bootstrap_memories_tool_returns_two_shared_retrieval_pages(monkeypatch):
+def test_prime_memory_context_returns_two_shared_retrieval_pages(monkeypatch):
 	seen = []
 	preference_memory = Memory(
 		id=1,
@@ -110,7 +110,7 @@ def test_bootstrap_memories_tool_returns_two_shared_retrieval_pages(monkeypatch)
 		"app.mcp_server.refresh_memories_last_accessed", fake_refresh_memories_last_accessed
 	)
 
-	result = bootstrap_memories_tool()
+	result = prime_memory_context()
 
 	assert seen == [
 		{
@@ -119,7 +119,7 @@ def test_bootstrap_memories_tool_returns_two_shared_retrieval_pages(monkeypatch)
 			"tag": None,
 			"q": None,
 			"sort": "updated_at",
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 		},
 		{
@@ -128,7 +128,7 @@ def test_bootstrap_memories_tool_returns_two_shared_retrieval_pages(monkeypatch)
 			"tag": None,
 			"q": None,
 			"sort": "updated_at",
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 		},
 	]
@@ -136,28 +136,28 @@ def test_bootstrap_memories_tool_returns_two_shared_retrieval_pages(monkeypatch)
 		"preferences": {
 			"items": [preference_memory.model_dump()],
 			"total": 1,
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 			"has_more": False,
 		},
 		"identities": {
 			"items": [identity_memory.model_dump()],
 			"total": 1,
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 			"has_more": False,
 		},
 	}
 
 
-def test_delete_memory_tool_raises_value_error_when_missing(monkeypatch):
+def test_retire_memory_raises_value_error_when_missing(monkeypatch):
 	monkeypatch.setattr("app.mcp_server.delete_memory", lambda memory_id: None)
 
 	with pytest.raises(ValueError, match="Memory 7 not found"):
-		delete_memory_tool(7)
+		retire_memory(7)
 
 
-def test_delete_memory_tool_returns_soft_deleted_memory(monkeypatch):
+def test_retire_memory_returns_soft_deleted_memory(monkeypatch):
 	deleted_memory = Memory(
 		id=7,
 		content="Unsafe note",
@@ -172,7 +172,7 @@ def test_delete_memory_tool_returns_soft_deleted_memory(monkeypatch):
 
 	monkeypatch.setattr("app.mcp_server.delete_memory", lambda memory_id: deleted_memory)
 
-	result = delete_memory_tool(7)
+	result = retire_memory(7)
 
 	assert result == {
 		"id": 7,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from app.mcp_server import (
+	bootstrap_memories_tool,
 	build_memories_tool_behavior_resource,
 	build_use_memories_api_prompt_messages,
 	create_memory_tool,
@@ -94,6 +95,94 @@ def test_query_memories_tool_uses_default_query_values(monkeypatch):
 	}
 
 
+def test_bootstrap_memories_tool_uses_canonical_startup_queries(monkeypatch):
+	seen_queries = []
+	preference_memory = Memory(
+		id=1,
+		content="User prefers concise answers.",
+		tags=["preference", "writing-style"],
+		created_at="2026-04-06T14:12:00.000000Z",
+		updated_at="2026-04-06T14:13:00.000000Z",
+		last_accessed_at=None,
+		memory_type="preference",
+		status="active",
+		version=1,
+	)
+	identity_memory = Memory(
+		id=2,
+		content="User is a software engineer.",
+		tags=["identity", "role"],
+		created_at="2026-04-06T14:12:00.000000Z",
+		updated_at="2026-04-06T14:14:00.000000Z",
+		last_accessed_at=None,
+		memory_type="identity",
+		status="active",
+		version=1,
+	)
+
+	def fake_get_memories_page(query):
+		seen_queries.append(query.model_dump())
+		if query.memory_type == "preference":
+			return [preference_memory], 1
+		return [identity_memory], 1
+
+	def fake_refresh_memories_last_accessed(memories):
+		return [
+			memory.model_copy(update={"last_accessed_at": f"refreshed-{memory.id}"})
+			for memory in memories
+		]
+
+	monkeypatch.setattr("app.mcp_server.get_memories_page", fake_get_memories_page)
+	monkeypatch.setattr(
+		"app.mcp_server.refresh_memories_last_accessed", fake_refresh_memories_last_accessed
+	)
+
+	result = bootstrap_memories_tool()
+
+	assert seen_queries == [
+		{
+			"status": "active",
+			"memory_type": "preference",
+			"tag": None,
+			"q": None,
+			"sort": "updated_at",
+			"limit": 5,
+			"offset": 0,
+		},
+		{
+			"status": "active",
+			"memory_type": "identity",
+			"tag": None,
+			"q": None,
+			"sort": "updated_at",
+			"limit": 5,
+			"offset": 0,
+		},
+	]
+	assert result == {
+		"preferences": {
+			"items": [
+				preference_memory.model_copy(
+					update={"last_accessed_at": "refreshed-1"}
+				).model_dump()
+			],
+			"total": 1,
+			"limit": 5,
+			"offset": 0,
+			"has_more": False,
+		},
+		"identities": {
+			"items": [
+				identity_memory.model_copy(update={"last_accessed_at": "refreshed-2"}).model_dump()
+			],
+			"total": 1,
+			"limit": 5,
+			"offset": 0,
+			"has_more": False,
+		},
+	}
+
+
 def test_update_memory_tool_omits_unset_optional_fields(monkeypatch):
 	seen = {}
 
@@ -172,6 +261,13 @@ def test_mcp_lists_static_memories_prompt():
 
 	assert prompt.description is not None
 	assert prompt.arguments == []
+
+
+def test_mcp_lists_bootstrap_memories_tool():
+	tools = asyncio.run(mcp.list_tools())
+	tool = next(item for item in tools if item.name == "bootstrap_memories_tool")
+
+	assert tool.name == "bootstrap_memories_tool"
 
 
 def test_mcp_gets_static_memories_prompt_messages():

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3,15 +3,15 @@ import asyncio
 import pytest
 
 from app.mcp_server import (
-	bootstrap_memories_tool,
 	build_memories_tool_behavior_resource,
 	build_use_memories_api_prompt_messages,
-	create_memory_tool,
+	inspect_memory,
 	mcp,
-	query_memories_tool,
-	read_memory,
+	prime_memory_context,
+	record_memory,
+	revise_memory,
+	search_memories,
 	serialize_memory,
-	update_memory_tool,
 )
 from app.schemas import Memory, MemoryUpdate
 
@@ -32,14 +32,14 @@ def test_serialize_memory_returns_model_dump():
 	assert serialize_memory(memory) == memory.model_dump()
 
 
-def test_read_memory_raises_value_error_when_missing(monkeypatch):
+def test_inspect_memory_raises_value_error_when_missing(monkeypatch):
 	monkeypatch.setattr("app.mcp_server.get_memory", lambda memory_id: None)
 
 	with pytest.raises(ValueError, match="Memory 99 not found"):
-		read_memory(99)
+		inspect_memory(99)
 
 
-def test_create_memory_tool_uses_schema_defaults(monkeypatch):
+def test_record_memory_uses_schema_defaults(monkeypatch):
 	created = {}
 
 	def fake_create_memory(memory):
@@ -58,14 +58,14 @@ def test_create_memory_tool_uses_schema_defaults(monkeypatch):
 
 	monkeypatch.setattr("app.mcp_server.create_memory", fake_create_memory)
 
-	result = create_memory_tool(content="Remember this", tags=["note"])
+	result = record_memory(content="Remember this", tags=["note"])
 
 	assert created["memory"].memory_type == "fact"
 	assert created["memory"].status == "active"
 	assert result["content"] == "Remember this"
 
 
-def test_query_memories_tool_uses_default_query_values(monkeypatch):
+def test_search_memories_uses_default_query_values(monkeypatch):
 	seen = {}
 
 	def fake_get_memories_page(query):
@@ -75,7 +75,7 @@ def test_query_memories_tool_uses_default_query_values(monkeypatch):
 	monkeypatch.setattr("app.mcp_server.get_memories_page", fake_get_memories_page)
 	monkeypatch.setattr("app.mcp_server.refresh_memories_last_accessed", lambda memories: memories)
 
-	result = query_memories_tool()
+	result = search_memories()
 
 	assert seen["query"].model_dump() == {
 		"status": None,
@@ -95,7 +95,7 @@ def test_query_memories_tool_uses_default_query_values(monkeypatch):
 	}
 
 
-def test_bootstrap_memories_tool_uses_canonical_startup_queries(monkeypatch):
+def test_prime_memory_context_uses_canonical_startup_queries(monkeypatch):
 	seen_queries = []
 	preference_memory = Memory(
 		id=1,
@@ -137,7 +137,7 @@ def test_bootstrap_memories_tool_uses_canonical_startup_queries(monkeypatch):
 		"app.mcp_server.refresh_memories_last_accessed", fake_refresh_memories_last_accessed
 	)
 
-	result = bootstrap_memories_tool()
+	result = prime_memory_context()
 
 	assert seen_queries == [
 		{
@@ -146,7 +146,7 @@ def test_bootstrap_memories_tool_uses_canonical_startup_queries(monkeypatch):
 			"tag": None,
 			"q": None,
 			"sort": "updated_at",
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 		},
 		{
@@ -155,7 +155,7 @@ def test_bootstrap_memories_tool_uses_canonical_startup_queries(monkeypatch):
 			"tag": None,
 			"q": None,
 			"sort": "updated_at",
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 		},
 	]
@@ -167,7 +167,7 @@ def test_bootstrap_memories_tool_uses_canonical_startup_queries(monkeypatch):
 				).model_dump()
 			],
 			"total": 1,
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 			"has_more": False,
 		},
@@ -176,14 +176,14 @@ def test_bootstrap_memories_tool_uses_canonical_startup_queries(monkeypatch):
 				identity_memory.model_copy(update={"last_accessed_at": "refreshed-2"}).model_dump()
 			],
 			"total": 1,
-			"limit": 5,
+			"limit": 10,
 			"offset": 0,
 			"has_more": False,
 		},
 	}
 
 
-def test_update_memory_tool_omits_unset_optional_fields(monkeypatch):
+def test_revise_memory_omits_unset_optional_fields(monkeypatch):
 	seen = {}
 
 	def fake_update_memory(memory_id, memory):
@@ -203,7 +203,7 @@ def test_update_memory_tool_omits_unset_optional_fields(monkeypatch):
 
 	monkeypatch.setattr("app.mcp_server.update_memory", fake_update_memory)
 
-	result = update_memory_tool(7, content="Updated memory content")
+	result = revise_memory(7, content="Updated memory content")
 
 	assert seen["memory_id"] == 7
 	assert isinstance(seen["memory"], MemoryUpdate)
@@ -216,11 +216,11 @@ def test_build_memories_tool_behavior_resource_includes_policy_and_recipes():
 
 	assert "# Memories Tool Behavior Policy" in resource_text
 	assert "# Query Recipes" in resource_text
-	assert "bootstrap_memories_tool" in resource_text
+	assert "prime_memory_context" in resource_text
 	assert "### Sensitive Data" in resource_text
 	assert "## Deduping and Updates" in resource_text
 	assert "## Tag Guidance" in resource_text
-	assert "query_memories_tool" in resource_text
+	assert "search_memories" in resource_text
 
 
 def test_build_use_memories_api_prompt_messages_returns_static_messages():
@@ -228,8 +228,8 @@ def test_build_use_memories_api_prompt_messages_returns_static_messages():
 
 	assert [message.role for message in messages] == ["assistant"]
 	assert "memories-api MCP server" in messages[0].content.text
-	assert "bootstrap_memories_tool" in messages[0].content.text
-	assert "query_memories_tool" in messages[0].content.text
+	assert "prime_memory_context" in messages[0].content.text
+	assert "search_memories" in messages[0].content.text
 	assert "Default to autonomous memory handling" in messages[0].content.text
 	assert "sensitive markers" in messages[0].content.text
 	assert "Deduping process before writes" in messages[0].content.text
@@ -266,11 +266,11 @@ def test_mcp_lists_static_memories_prompt():
 	assert prompt.arguments == []
 
 
-def test_mcp_lists_bootstrap_memories_tool():
+def test_mcp_lists_prime_memory_context_tool():
 	tools = asyncio.run(mcp.list_tools())
-	tool = next(item for item in tools if item.name == "bootstrap_memories_tool")
+	tool = next(item for item in tools if item.name == "prime_memory_context")
 
-	assert tool.name == "bootstrap_memories_tool"
+	assert tool.name == "prime_memory_context"
 
 
 def test_mcp_gets_static_memories_prompt_messages():
@@ -278,7 +278,7 @@ def test_mcp_gets_static_memories_prompt_messages():
 
 	assert [message.role for message in prompt.messages] == ["assistant"]
 	assert "memories-api MCP server" in prompt.messages[0].content.text
-	assert "bootstrap_memories_tool" in prompt.messages[0].content.text
-	assert "query_memories_tool" in prompt.messages[0].content.text
+	assert "prime_memory_context" in prompt.messages[0].content.text
+	assert "search_memories" in prompt.messages[0].content.text
 	assert "Default to autonomous memory handling" in prompt.messages[0].content.text
 	assert "Memory actions:" in prompt.messages[0].content.text

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -216,6 +216,7 @@ def test_build_memories_tool_behavior_resource_includes_policy_and_recipes():
 
 	assert "# Memories Tool Behavior Policy" in resource_text
 	assert "# Query Recipes" in resource_text
+	assert "bootstrap_memories_tool" in resource_text
 	assert "### Sensitive Data" in resource_text
 	assert "## Deduping and Updates" in resource_text
 	assert "## Tag Guidance" in resource_text
@@ -227,6 +228,8 @@ def test_build_use_memories_api_prompt_messages_returns_static_messages():
 
 	assert [message.role for message in messages] == ["assistant"]
 	assert "memories-api MCP server" in messages[0].content.text
+	assert "bootstrap_memories_tool" in messages[0].content.text
+	assert "query_memories_tool" in messages[0].content.text
 	assert "Default to autonomous memory handling" in messages[0].content.text
 	assert "sensitive markers" in messages[0].content.text
 	assert "Deduping process before writes" in messages[0].content.text
@@ -275,5 +278,7 @@ def test_mcp_gets_static_memories_prompt_messages():
 
 	assert [message.role for message in prompt.messages] == ["assistant"]
 	assert "memories-api MCP server" in prompt.messages[0].content.text
+	assert "bootstrap_memories_tool" in prompt.messages[0].content.text
+	assert "query_memories_tool" in prompt.messages[0].content.text
 	assert "Default to autonomous memory handling" in prompt.messages[0].content.text
 	assert "Memory actions:" in prompt.messages[0].content.text


### PR DESCRIPTION
## Summary

This branch turns the memories MCP surface from a thin CRUD wrapper into an agent-oriented workflow layer. It makes startup context bootstrap first-class, aligns prompt and policy language with the intended operating model, and renames tool functions to clearer action verbs with discriminative descriptions.

## What changed

- Added a combined `prime_memory_context` startup path for preference and identity recall.
- Reworked MCP prompt and policy/resource text to emphasize query-before-write discipline, deduping, contradiction handling, and sensitive-data confirmation.
- Renamed MCP tool functions to action-verb aliases: `record_memory`, `revise_memory`, `retire_memory`, `search_memories`, `prime_memory_context`, and `inspect_memory`.
- Expanded tool descriptions so the model can choose the right tool from intent, not endpoint shape.
- Updated README content, skill assets, docs, and tests to match the new workflow surface.
- Removed compatibility wrappers after the references were updated.

## Compatibility

This branch intentionally changes the public MCP tool names. External callers should update to the new action-verb aliases.

## Validation

- `pytest`
- `python .github/skills/memories/scripts/validate_memories_skill.py`
- `ruff check .`
- `ruff format --check .`