### PR TITLE
Normalize whitespace in memory list text filters

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -161,9 +161,10 @@ class MemoryListQuery(BaseModel):
 			return value
 		if not isinstance(value, str):
 			raise ValueError("filter must be a string")
-		if not value.strip():
+		normalized_value = value.strip()
+		if not normalized_value:
 			raise ValueError("filter cannot be empty")
-		return value
+		return normalized_value
 
 
 class MemoryListResponse(BaseModel):

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -79,8 +79,8 @@ def test_memory_list_query_validates_status_memory_type_and_text_filters():
 	query = MemoryListQuery(
 		status="active",
 		memory_type="identity",
-		tag="python",
-		q="fastapi",
+		tag=" python ",
+		q=" fastapi ",
 	)
 
 	assert query.status == "active"


### PR DESCRIPTION
## Summary
- Strip leading/trailing whitespace from `tag` and `q` memory list filters during validation
- Keep whitespace-only filters invalid
- Add schema coverage for normalized text filters

## Testing
- `pytest tests/unit/test_schemas.py`
- `ruff format .`
- `ruff check .`
- `pytest`

Issue Link
Closes #13