### PR TITLE
Preserve valid browser origins when some client entries are invalid

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -58,10 +58,7 @@ def load_browser_client_config() -> BrowserClientConfig:
 
 		allowed_origins.append(origin)
 
-	if warnings:
-		return BrowserClientConfig(allowed_origins=[], warnings=warnings)
-
-	return BrowserClientConfig(allowed_origins=allowed_origins, warnings=[])
+	return BrowserClientConfig(allowed_origins=allowed_origins, warnings=warnings)
 
 
 def get_database_file_path() -> Path:

--- a/tests/contract/test_mcp_http_transport.py
+++ b/tests/contract/test_mcp_http_transport.py
@@ -56,6 +56,27 @@ def test_mcp_http_allows_configured_browser_origin(monkeypatch, tmp_path: Path):
 	assert response.status_code != 404
 
 
+def test_mcp_http_allows_valid_origin_when_another_browser_client_is_invalid(
+	monkeypatch, tmp_path: Path
+):
+	with build_client_with_browser_config(
+		monkeypatch,
+		tmp_path,
+		[
+			{"name": "open-webui-local", "origin": "http://localhost:3000"},
+			{"name": "missing-origin"},
+		],
+	) as client:
+		response = client.post(
+			"/mcp",
+			headers={"Origin": "http://localhost:3000"},
+			json={},
+		)
+
+	assert response.status_code != 403
+	assert response.status_code != 404
+
+
 def test_mcp_http_allows_mcp_request_headers_for_allowed_origin(monkeypatch, tmp_path: Path):
 	with build_client_with_browser_config(
 		monkeypatch,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -72,3 +72,32 @@ def test_load_browser_client_config_returns_exact_allowed_origins(monkeypatch, t
 
 	assert config.allowed_origins == ["http://localhost:3000", "http://127.0.0.1:8080"]
 	assert config.warnings == []
+
+
+def test_load_browser_client_config_preserves_valid_origins_when_entries_are_invalid(
+	monkeypatch, tmp_path: Path
+):
+	config_path = tmp_path / "mcp_browser_clients.local.json"
+	config_path.write_text(
+		json.dumps(
+			{
+				"browser_clients": [
+					{
+						"name": "open-webui-local",
+						"origin": "http://localhost:3000",
+					},
+					{
+						"name": "missing-origin",
+					},
+				],
+			}
+		),
+		encoding="utf-8",
+	)
+	monkeypatch.setattr("app.config.MCP_BROWSER_CLIENTS_LOCAL_FILE", config_path)
+
+	config = load_browser_client_config()
+
+	assert config.allowed_origins == ["http://localhost:3000"]
+	assert len(config.warnings) == 1
+	assert "browser_clients[1]" in config.warnings[0]


### PR DESCRIPTION
## Summary
- Keep valid `allowed_origins` from `mcp_browser_clients.local.json` even when some `browser_clients` entries are malformed.
- Preserve warning reporting for invalid entries while reserving deny-all behavior for top-level config failures.
- Add regression coverage for both the config loader and the MCP HTTP origin check.

## Testing
- Added a unit test covering mixed valid and invalid browser client entries.
- Added a contract test proving a valid origin still passes through the MCP HTTP path when another entry is malformed.
- Linting and formatting passed, and the full test suite passed in commit hooks.

Issue Link
Closes https://github.com/laceyp99/Memories-API/issues/10