### PR TITLE
fix consistent memory pagination snapshots

### DIFF
--- a/app/storage.py
+++ b/app/storage.py
@@ -205,6 +205,7 @@ def get_memories_page(query: MemoryListQuery) -> tuple[list[Memory], int]:
 	paging_parameters = [*parameters, query.limit, query.offset]
 
 	with get_connection() as connection:
+		connection.execute("BEGIN")
 		total = connection.execute(
 			f"SELECT COUNT(*) FROM memories {where_clause}",
 			parameters,
@@ -219,6 +220,7 @@ def get_memories_page(query: MemoryListQuery) -> tuple[list[Memory], int]:
 			""",
 			paging_parameters,
 		).fetchall()
+		connection.commit()
 
 	return [_row_to_memory(row) for row in rows], total
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.schemas import MemoryCreate, MemoryListQuery, MemoryUpdate
 from app.storage import (
 	create_memory,
@@ -111,6 +113,58 @@ def test_get_memories_page_sorts_by_last_accessed_at_and_counts_full_result(monk
 
 	assert total == 3
 	assert [memory.id for memory in items] == [2, 1]
+
+
+@pytest.mark.xfail(reason="get_memories_page does not yet start a read transaction", strict=True)
+def test_get_memories_page_reads_count_and_rows_in_one_transaction(monkeypatch):
+	executed_statements: list[str] = []
+
+	class FakeResult:
+		def __init__(self, *, one=None, all_rows=None):
+			self._one = one
+			self._all_rows = all_rows or []
+
+		def fetchone(self):
+			return self._one
+
+		def fetchall(self):
+			return self._all_rows
+
+	class FakeConnection:
+		def execute(self, sql, parameters=()):
+			normalized_sql = " ".join(sql.split()).upper()
+
+			if normalized_sql == "BEGIN":
+				executed_statements.append("BEGIN")
+				return FakeResult()
+
+			if "SELECT COUNT(*) FROM MEMORIES" in normalized_sql:
+				executed_statements.append("COUNT")
+				return FakeResult(one=(0,))
+
+			if "SELECT ID, CONTENT, TAGS" in normalized_sql:
+				executed_statements.append("PAGE")
+				return FakeResult(all_rows=[])
+
+			raise AssertionError(f"Unexpected SQL: {sql}")
+
+		def commit(self):
+			executed_statements.append("COMMIT")
+
+	class FakeConnectionContext:
+		def __enter__(self):
+			return FakeConnection()
+
+		def __exit__(self, _exc_type, _exc_value, _traceback):
+			return False
+
+	monkeypatch.setattr("app.storage.get_connection", lambda: FakeConnectionContext())
+
+	items, total = get_memories_page(MemoryListQuery(limit=2, offset=0))
+
+	assert items == []
+	assert total == 0
+	assert executed_statements == ["BEGIN", "COUNT", "PAGE", "COMMIT"]
 
 
 def test_update_memory_returns_existing_memory_without_refreshing_timestamp(monkeypatch):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,5 +1,3 @@
-import pytest
-
 from app.schemas import MemoryCreate, MemoryListQuery, MemoryUpdate
 from app.storage import (
 	create_memory,
@@ -115,7 +113,6 @@ def test_get_memories_page_sorts_by_last_accessed_at_and_counts_full_result(monk
 	assert [memory.id for memory in items] == [2, 1]
 
 
-@pytest.mark.xfail(reason="get_memories_page does not yet start a read transaction", strict=True)
 def test_get_memories_page_reads_count_and_rows_in_one_transaction(monkeypatch):
 	executed_statements: list[str] = []
 


### PR DESCRIPTION
﻿## Related Links

- Github Issue: #11

## What

- Wrapped `get_memories_page()` count and page-row reads in one explicit SQLite transaction.
- Added a focused storage regression test that verifies the count query and paginated row query are enclosed by `BEGIN` and `COMMIT`.
- Preserved the existing pagination response shape and `get_memories_page()` return contract.

## Why

- Paginated memory list responses currently build `items`, `total`, and `has_more` from count/page reads that can observe different database states under concurrent writes.
- Reading both queries from one SQLite snapshot keeps pagination metadata internally consistent without changing API or MCP behavior.

## How

- Kept the existing two-query pagination design.
- Started a short read transaction before `SELECT COUNT(*)`, fetched the requested page rows inside the same transaction, then committed immediately after both reads complete.
- Covered the behavior at the storage layer so future changes preserve the snapshot boundary.

## Test Steps

- [x] `ruff format --check .` - passed
- [x] `ruff check .` - passed
- [x] `pytest` - passed
- [x] `pre-commit run --all-files` - passed

## Other Notes

- `refresh_memories_last_accessed()` remains outside this transaction; the consistency fix is scoped to reading the page `items` and `total` from the same snapshot.
- No API or MCP response fields were changed.
