### PR TITLE
prevent stale memory write conflicts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.schemas import (
 	MemoryUpdate,
 )
 from app.storage import (
+	MemoryWriteConflictError,
 	create_memory,
 	create_memory_batch,
 	delete_memory,
@@ -98,7 +99,14 @@ def get_memory_by_id(memory_id: int) -> Memory:
 
 @app.patch("/memories/{memory_id}")
 def patch_memory_by_id(memory_id: int, memory: MemoryUpdate) -> Memory:
-	updated_memory = update_memory(memory_id, memory)
+	try:
+		updated_memory = update_memory(memory_id, memory)
+	except MemoryWriteConflictError as error:
+		raise HTTPException(
+			status_code=409,
+			detail="Memory was modified by another request",
+		) from error
+
 	if updated_memory is None:
 		raise HTTPException(status_code=404, detail="Memory not found")
 	return updated_memory
@@ -106,7 +114,14 @@ def patch_memory_by_id(memory_id: int, memory: MemoryUpdate) -> Memory:
 
 @app.delete("/memories/{memory_id}")
 def delete_memory_by_id(memory_id: int) -> Memory:
-	deleted_memory = delete_memory(memory_id)
+	try:
+		deleted_memory = delete_memory(memory_id)
+	except MemoryWriteConflictError as error:
+		raise HTTPException(
+			status_code=409,
+			detail="Memory was modified by another request",
+		) from error
+
 	if deleted_memory is None:
 		raise HTTPException(status_code=404, detail="Memory not found")
 	return deleted_memory

--- a/app/storage.py
+++ b/app/storage.py
@@ -12,6 +12,10 @@ MEMORY_SORT_COLUMNS = {
 }
 
 
+class MemoryWriteConflictError(RuntimeError):
+	"""Raised when a memory write loses an optimistic locking race."""
+
+
 def current_timestamp() -> str:
 	return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
@@ -281,11 +285,11 @@ def update_memory(memory_id: int, memory: MemoryUpdate) -> Memory | None:
 		updated_memory = existing_memory.model_copy(update=update_data)
 		updated_at = current_timestamp()
 		version = existing_memory.version + 1
-		connection.execute(
+		cursor = connection.execute(
 			"""
 			UPDATE memories
 			SET content = ?, tags = ?, updated_at = ?, memory_type = ?, status = ?, version = ?
-			WHERE id = ?
+			WHERE id = ? AND status != 'deleted' AND version = ?
 			""",
 			(
 				updated_memory.content,
@@ -295,8 +299,12 @@ def update_memory(memory_id: int, memory: MemoryUpdate) -> Memory | None:
 				updated_memory.status,
 				version,
 				memory_id,
+				existing_memory.version,
 			),
 		)
+		if cursor.rowcount == 0:
+			connection.rollback()
+			raise MemoryWriteConflictError(f"Memory {memory_id} was modified by another request")
 		connection.commit()
 
 		return updated_memory.model_copy(update={"updated_at": updated_at, "version": version})
@@ -311,14 +319,17 @@ def delete_memory(memory_id: int) -> Memory | None:
 		existing_memory = _row_to_memory(row)
 		updated_at = current_timestamp()
 		version = existing_memory.version + 1
-		connection.execute(
+		cursor = connection.execute(
 			"""
 			UPDATE memories
 			SET status = ?, updated_at = ?, version = ?
-			WHERE id = ?
+			WHERE id = ? AND status != 'deleted' AND version = ?
 			""",
-			("deleted", updated_at, version, memory_id),
+			("deleted", updated_at, version, memory_id, existing_memory.version),
 		)
+		if cursor.rowcount == 0:
+			connection.rollback()
+			raise MemoryWriteConflictError(f"Memory {memory_id} was modified by another request")
 		connection.commit()
 		return existing_memory.model_copy(
 			update={"status": "deleted", "updated_at": updated_at, "version": version}

--- a/tests/contract/test_http_contract.py
+++ b/tests/contract/test_http_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 from helpers.database_helpers import read_database
 
+from app import main as app_main
 from app import storage
 
 
@@ -45,6 +46,36 @@ def test_missing_memory_returns_documented_404_shape(client: TestClient, data_fi
 
 	assert response.status_code == 404
 	assert response.json() == {"detail": "Memory not found"}
+	assert read_database(data_file) == []
+
+
+def test_patch_memory_conflict_returns_documented_409_shape(
+	client: TestClient, data_file: Path, monkeypatch
+):
+	def raise_conflict(_memory_id, _memory):
+		raise storage.MemoryWriteConflictError("stale write")
+
+	monkeypatch.setattr(app_main, "update_memory", raise_conflict)
+
+	response = client.patch("/memories/1", json={"content": "Updated content"})
+
+	assert response.status_code == 409
+	assert response.json() == {"detail": "Memory was modified by another request"}
+	assert read_database(data_file) == []
+
+
+def test_delete_memory_conflict_returns_documented_409_shape(
+	client: TestClient, data_file: Path, monkeypatch
+):
+	def raise_conflict(_memory_id):
+		raise storage.MemoryWriteConflictError("stale write")
+
+	monkeypatch.setattr(app_main, "delete_memory", raise_conflict)
+
+	response = client.delete("/memories/1")
+
+	assert response.status_code == 409
+	assert response.json() == {"detail": "Memory was modified by another request"}
 	assert read_database(data_file) == []
 
 

--- a/tests/integration/test_memories_delete.py
+++ b/tests/integration/test_memories_delete.py
@@ -1,3 +1,4 @@
+import sqlite3
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -56,6 +57,68 @@ def test_delete_memory_by_id_returns_deleted_memory_with_full_shape(
 
 	assert response.status_code == 200
 	assert response.json() == expected
+	assert read_database(data_file) == [expected]
+
+
+def test_delete_memory_by_id_stale_write_returns_409(
+	client: TestClient, data_file: Path, monkeypatch
+):
+	create_timestamp = "2026-04-06T14:12:00.000000Z"
+	concurrent_timestamp = "2026-04-06T14:20:00.000000Z"
+	monkeypatch.setattr(storage, "current_timestamp", lambda: create_timestamp)
+
+	create_response = client.post(
+		"/memories",
+		json={
+			"content": "Learning FastAPI testing",
+			"tags": ["python", "api"],
+		},
+	)
+	assert create_response.status_code == 200
+
+	original_fetch = storage._fetch_visible_memory_row
+	did_concurrent_write = False
+
+	def fetch_then_change_row(connection, memory_id):
+		nonlocal did_concurrent_write
+
+		row = original_fetch(connection, memory_id)
+		if row is not None and not did_concurrent_write:
+			did_concurrent_write = True
+			with sqlite3.connect(data_file) as concurrent_connection:
+				concurrent_connection.execute(
+					"""
+					UPDATE memories
+					SET content = ?, updated_at = ?, version = ?
+					WHERE id = ?
+					""",
+					(
+						"Concurrent update",
+						concurrent_timestamp,
+						row["version"] + 1,
+						memory_id,
+					),
+				)
+				concurrent_connection.commit()
+
+		return row
+
+	monkeypatch.setattr(storage, "_fetch_visible_memory_row", fetch_then_change_row)
+
+	response = client.delete("/memories/1")
+
+	expected = expected_memory(
+		1,
+		"Concurrent update",
+		["python", "api"],
+		created_at=create_timestamp,
+		updated_at=concurrent_timestamp,
+		last_accessed_at=None,
+		version=2,
+	)
+
+	assert response.status_code == 409
+	assert response.json() == {"detail": "Memory was modified by another request"}
 	assert read_database(data_file) == [expected]
 
 

--- a/tests/integration/test_memories_update.py
+++ b/tests/integration/test_memories_update.py
@@ -1,3 +1,4 @@
+import sqlite3
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -162,6 +163,68 @@ def test_patch_memory_by_id_no_op_does_not_change_updated_at_or_version(
 
 	assert response.status_code == 200
 	assert response.json() == expected
+	assert read_database(data_file) == [expected]
+
+
+def test_patch_memory_by_id_stale_write_returns_409(
+	client: TestClient, data_file: Path, monkeypatch
+):
+	create_timestamp = "2026-04-06T14:12:00.000000Z"
+	concurrent_timestamp = "2026-04-06T14:20:00.000000Z"
+	monkeypatch.setattr(storage, "current_timestamp", lambda: create_timestamp)
+
+	create_response = client.post(
+		"/memories",
+		json={
+			"content": "Learning FastAPI testing",
+			"tags": ["python", "api"],
+		},
+	)
+	assert create_response.status_code == 200
+
+	original_fetch = storage._fetch_visible_memory_row
+	did_concurrent_write = False
+
+	def fetch_then_change_row(connection, memory_id):
+		nonlocal did_concurrent_write
+
+		row = original_fetch(connection, memory_id)
+		if row is not None and not did_concurrent_write:
+			did_concurrent_write = True
+			with sqlite3.connect(data_file) as concurrent_connection:
+				concurrent_connection.execute(
+					"""
+					UPDATE memories
+					SET content = ?, updated_at = ?, version = ?
+					WHERE id = ?
+					""",
+					(
+						"Concurrent update",
+						concurrent_timestamp,
+						row["version"] + 1,
+						memory_id,
+					),
+				)
+				concurrent_connection.commit()
+
+		return row
+
+	monkeypatch.setattr(storage, "_fetch_visible_memory_row", fetch_then_change_row)
+
+	response = client.patch("/memories/1", json={"content": "Stale update"})
+
+	expected = expected_memory(
+		1,
+		"Concurrent update",
+		["python", "api"],
+		created_at=create_timestamp,
+		updated_at=concurrent_timestamp,
+		last_accessed_at=None,
+		version=2,
+	)
+
+	assert response.status_code == 409
+	assert response.json() == {"detail": "Memory was modified by another request"}
 	assert read_database(data_file) == [expected]
 
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,6 +1,13 @@
+import sqlite3
+
+import pytest
+from helpers.database_helpers import read_database
+
+from app import storage
 from app.schemas import MemoryCreate, MemoryListQuery, MemoryUpdate
 from app.storage import (
 	create_memory,
+	delete_memory,
 	get_memories,
 	get_memories_page,
 	update_memory,
@@ -192,3 +199,105 @@ def test_update_memory_persists_changes(monkeypatch):
 	assert result.status == "invalid"
 	assert result.updated_at == "2026-04-06T14:30:00.000000Z"
 	assert result.version == 2
+
+
+def test_update_memory_raises_conflict_when_row_changes_after_visible_read(data_file, monkeypatch):
+	create_memory(MemoryCreate(content="Initial content", tags=["initial"]))
+	original_fetch = storage._fetch_visible_memory_row
+	did_concurrent_write = False
+
+	def fetch_then_change_row(connection, memory_id):
+		nonlocal did_concurrent_write
+
+		row = original_fetch(connection, memory_id)
+		if row is not None and not did_concurrent_write:
+			did_concurrent_write = True
+			with sqlite3.connect(data_file) as concurrent_connection:
+				concurrent_connection.execute(
+					"""
+					UPDATE memories
+					SET content = ?, updated_at = ?, version = ?
+					WHERE id = ?
+					""",
+					(
+						"Concurrent update",
+						"2026-04-06T14:20:00.000000Z",
+						row["version"] + 1,
+						memory_id,
+					),
+				)
+				concurrent_connection.commit()
+
+		return row
+
+	monkeypatch.setattr(storage, "_fetch_visible_memory_row", fetch_then_change_row)
+	conflict_error = getattr(storage, "MemoryWriteConflictError", Exception)
+
+	with pytest.raises(conflict_error):
+		update_memory(1, MemoryUpdate(content="Stale update"))
+
+	rows = read_database(data_file)
+	assert rows == [
+		{
+			"id": 1,
+			"content": "Concurrent update",
+			"tags": ["initial"],
+			"created_at": rows[0]["created_at"],
+			"updated_at": "2026-04-06T14:20:00.000000Z",
+			"last_accessed_at": None,
+			"memory_type": "fact",
+			"status": "active",
+			"version": 2,
+		}
+	]
+
+
+def test_delete_memory_raises_conflict_when_row_changes_after_visible_read(data_file, monkeypatch):
+	create_memory(MemoryCreate(content="Initial content", tags=["initial"]))
+	original_fetch = storage._fetch_visible_memory_row
+	did_concurrent_write = False
+
+	def fetch_then_change_row(connection, memory_id):
+		nonlocal did_concurrent_write
+
+		row = original_fetch(connection, memory_id)
+		if row is not None and not did_concurrent_write:
+			did_concurrent_write = True
+			with sqlite3.connect(data_file) as concurrent_connection:
+				concurrent_connection.execute(
+					"""
+					UPDATE memories
+					SET content = ?, updated_at = ?, version = ?
+					WHERE id = ?
+					""",
+					(
+						"Concurrent update",
+						"2026-04-06T14:20:00.000000Z",
+						row["version"] + 1,
+						memory_id,
+					),
+				)
+				concurrent_connection.commit()
+
+		return row
+
+	monkeypatch.setattr(storage, "_fetch_visible_memory_row", fetch_then_change_row)
+	conflict_error = getattr(storage, "MemoryWriteConflictError", Exception)
+
+	with pytest.raises(conflict_error):
+		delete_memory(1)
+
+	rows = read_database(data_file)
+	assert rows == [
+		{
+			"id": 1,
+			"content": "Concurrent update",
+			"tags": ["initial"],
+			"created_at": rows[0]["created_at"],
+			"updated_at": "2026-04-06T14:20:00.000000Z",
+			"last_accessed_at": None,
+			"memory_type": "fact",
+			"status": "active",
+			"version": 2,
+		}
+	]


### PR DESCRIPTION
﻿## Related Links

- Github Issue: Fixes #9

## What

- Added optimistic locking to stale-sensitive `PATCH` and `DELETE` storage writes using the previously read memory `version` and visible status.
- Added a storage-level `MemoryWriteConflictError` and mapped it to HTTP `409 Conflict` for stale write attempts.
- Added storage, integration, and contract coverage for stale write conflicts while preserving existing success, no-op, and `404 Memory not found` behavior.

## Why

- Prevents a stale memory write from silently overwriting newer memory state after another client or agent has modified the same row.
- Gives API clients a stable conflict response so they can re-read the current memory before retrying.

## How

- Made final storage `UPDATE` statements conditional on `id`, non-deleted status, and the version observed during the initial visible-row read.
- Checked affected row counts after conditional writes and rolled back/raised a conflict when another request changed the row first.
- Kept omitted-field merge behavior, no-op PATCH behavior, and successful response shapes unchanged.

## Test Steps

- [x] `ruff format --check .` - passed
- [x] `ruff check .` - passed
- [x] `pytest` - passed, 95 tests

## Other Notes

- No public memory schema changes.
- No client-provided `version`, `ETag`, or `If-Match` requirement added.
