### PR TITLE
Add local request safety limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ mcp_browser_clients.local.json
 *.sqlite-wal
 *.sqlite-shm
 data.db
+
+# Generated stress reports
+scripts/rate_limit_report.html

--- a/README.md
+++ b/README.md
@@ -133,6 +133,33 @@ For a local Open WebUI setup, two values matter:
 - Browser origin: usually `http://localhost:3000`. This is what goes into `mcp_browser_clients.local.json`.
 - MCP server URL: if Open WebUI runs in Docker, it may need `http://host.docker.internal:8000/mcp` instead of `http://localhost:8000/mcp` to reach the host machine.
 
+### Local safety limits
+
+The HTTP API and MCP streamable HTTP endpoint include conservative local safety limits by default. These are intended to protect a single-user local service from runaway agents, oversized payloads, and accidental request floods. They are not a substitute for authentication or transport security.
+
+Schema and API limits:
+
+- Memory `content` is capped at `8,000` characters.
+- A memory can have at most `20` tags.
+- Each tag is capped at `64` characters.
+- `tag` and `q` retrieval filters are capped at `256` characters.
+- `POST /memories/batch` accepts at most `25` memories.
+
+Runtime limits are configured with environment variables:
+
+| Environment variable | Default | Notes |
+| --- | ---: | --- |
+| `MEMORIES_RATE_LIMITING_ENABLED` | `true` | Set to `false` only as a local debugging escape hatch. |
+| `MEMORIES_RATE_LIMIT_READS_PER_MINUTE` | `120` | Applies to REST memory reads. Reads refresh `last_accessed_at`. |
+| `MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE` | `30` | Applies to REST create, update, and delete requests. |
+| `MEMORIES_RATE_LIMIT_BATCH_PER_MINUTE` | `10` | Applies to `POST /memories/batch`. |
+| `MEMORIES_RATE_LIMIT_MCP_PER_MINUTE` | `240` | Applies to MCP streamable HTTP traffic under `/mcp`. |
+| `MEMORIES_REQUEST_BODY_MAX_BYTES` | `1048576` | Applies to `POST` and `PATCH` REST/MCP HTTP requests with `Content-Length`. |
+
+Rate limiting uses a fixed 60-second in-memory window per process. Clients are identified by a trimmed `X-Client-Id` header, capped at 128 characters, when present; otherwise the client IP is used. A limited request returns `429` with `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers.
+
+Request body-size enforcement uses the `Content-Length` header and returns `413` with `X-Request-Body-Limit`. This covers normal local agent clients but does not fully cover oversized chunked or missing-length bodies.
+
 ## Retrieval contract
 
 HTTP and MCP expose one deterministic retrieval contract.
@@ -157,6 +184,7 @@ This project is intended for single-user, local-only use on a trusted machine.
 - Bind the HTTP API and MCP streamable HTTP endpoint to localhost only.
 - Browser-based MCP access is denied by default unless you create a local browser client allowlist file.
 - Browser origins are matched exactly.
+- Default local safety limits reduce accidental runaway behavior but do not make the service safe to expose beyond localhost.
 - Do not expose this service to the internet, a LAN, a shared VM, or a reverse proxy unless you add proper authentication, authorization, and transport security.
 - Treat the SQLite database file and local MCP/client configuration as sensitive local data.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ For a local Open WebUI setup, two values matter:
 - Browser origin: usually `http://localhost:3000`. This is what goes into `mcp_browser_clients.local.json`.
 - MCP server URL: if Open WebUI runs in Docker, it may need `http://host.docker.internal:8000/mcp` instead of `http://localhost:8000/mcp` to reach the host machine.
 
+## Retrieval contract
+
+HTTP and MCP expose one deterministic retrieval contract.
+
+- HTTP uses `GET /memories`.
+- MCP uses `prime_memory_context` for startup recall and `search_memories` for targeted recall.
+- Both accept `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
+- Both return `items`, `total`, `limit`, `offset`, and `has_more`.
+- `tag` matches exactly.
+- `q` is case-insensitive lexical matching over `content` and tags, not semantic search.
+- Filters compose with `AND`.
+- Sort keys are `id`, `created_at`, `updated_at`, and `last_accessed_at`; timestamp sorts are descending with `id DESC` as a tie-breaker.
+- `last_accessed_at` is refreshed only for rows actually returned by `GET /memories/{id}`, `GET /memories`, `search_memories`, and `prime_memory_context`.
+
+That keeps retrieval easy to test and consistent across HTTP and MCP.
+
 ### Local safety limits
 
 The HTTP API and MCP streamable HTTP endpoint include conservative local safety limits by default. These are intended to protect a single-user local service from runaway agents, oversized payloads, and accidental request floods. They are not a substitute for authentication or transport security.
@@ -160,21 +176,6 @@ Rate limiting uses a fixed 60-second in-memory window per process. Clients are i
 
 Request body-size enforcement uses the `Content-Length` header and returns `413` with `X-Request-Body-Limit`. This covers normal local agent clients but does not fully cover oversized chunked or missing-length bodies.
 
-## Retrieval contract
-
-HTTP and MCP expose one deterministic retrieval contract.
-
-- HTTP uses `GET /memories`.
-- MCP uses `prime_memory_context` for startup recall and `search_memories` for targeted recall.
-- Both accept `status`, `memory_type`, `tag`, `q`, `sort`, `limit`, and `offset`.
-- Both return `items`, `total`, `limit`, `offset`, and `has_more`.
-- `tag` matches exactly.
-- `q` is case-insensitive lexical matching over `content` and tags, not semantic search.
-- Filters compose with `AND`.
-- Sort keys are `id`, `created_at`, `updated_at`, and `last_accessed_at`; timestamp sorts are descending with `id DESC` as a tie-breaker.
-- `last_accessed_at` is refreshed only for rows actually returned by `GET /memories/{id}`, `GET /memories`, `search_memories`, and `prime_memory_context`.
-
-That keeps retrieval easy to test and consistent across HTTP and MCP.
 
 ## Security
 

--- a/app/config.py
+++ b/app/config.py
@@ -6,12 +6,62 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parent.parent
 MCP_BROWSER_CLIENTS_EXAMPLE_FILE = ROOT_DIR / "mcp_browser_clients.example.json"
 MCP_BROWSER_CLIENTS_LOCAL_FILE = ROOT_DIR / "mcp_browser_clients.local.json"
+DEFAULT_RATE_LIMITING_ENABLED = True
+DEFAULT_RATE_LIMIT_READS_PER_MINUTE = 120
+DEFAULT_RATE_LIMIT_WRITES_PER_MINUTE = 30
+DEFAULT_RATE_LIMIT_BATCH_PER_MINUTE = 10
+DEFAULT_RATE_LIMIT_MCP_PER_MINUTE = 240
+DEFAULT_REQUEST_BODY_MAX_BYTES = 1_048_576
 
 
 @dataclass(frozen=True)
 class BrowserClientConfig:
 	allowed_origins: list[str]
 	warnings: list[str]
+
+
+@dataclass(frozen=True)
+class SafetyConfig:
+	rate_limiting_enabled: bool
+	rate_limit_reads_per_minute: int
+	rate_limit_writes_per_minute: int
+	rate_limit_batch_per_minute: int
+	rate_limit_mcp_per_minute: int
+	request_body_max_bytes: int
+	warnings: list[str]
+
+
+def _parse_bool_env(name: str, default: bool, warnings: list[str]) -> bool:
+	value = os.getenv(name)
+	if value is None:
+		return default
+
+	normalized_value = value.strip().lower()
+	if normalized_value in {"1", "true", "yes", "on"}:
+		return True
+	if normalized_value in {"0", "false", "no", "off"}:
+		return False
+
+	warnings.append(f"{name} must be a boolean value. Using default {default}.")
+	return default
+
+
+def _parse_positive_int_env(name: str, default: int, warnings: list[str]) -> int:
+	value = os.getenv(name)
+	if value is None:
+		return default
+
+	try:
+		parsed_value = int(value)
+	except ValueError:
+		warnings.append(f"{name} must be a positive integer. Using default {default}.")
+		return default
+
+	if parsed_value <= 0:
+		warnings.append(f"{name} must be a positive integer. Using default {default}.")
+		return default
+
+	return parsed_value
 
 
 def load_browser_client_config() -> BrowserClientConfig:
@@ -59,6 +109,44 @@ def load_browser_client_config() -> BrowserClientConfig:
 		allowed_origins.append(origin)
 
 	return BrowserClientConfig(allowed_origins=allowed_origins, warnings=warnings)
+
+
+def load_safety_config() -> SafetyConfig:
+	warnings: list[str] = []
+
+	return SafetyConfig(
+		rate_limiting_enabled=_parse_bool_env(
+			"MEMORIES_RATE_LIMITING_ENABLED",
+			DEFAULT_RATE_LIMITING_ENABLED,
+			warnings,
+		),
+		rate_limit_reads_per_minute=_parse_positive_int_env(
+			"MEMORIES_RATE_LIMIT_READS_PER_MINUTE",
+			DEFAULT_RATE_LIMIT_READS_PER_MINUTE,
+			warnings,
+		),
+		rate_limit_writes_per_minute=_parse_positive_int_env(
+			"MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE",
+			DEFAULT_RATE_LIMIT_WRITES_PER_MINUTE,
+			warnings,
+		),
+		rate_limit_batch_per_minute=_parse_positive_int_env(
+			"MEMORIES_RATE_LIMIT_BATCH_PER_MINUTE",
+			DEFAULT_RATE_LIMIT_BATCH_PER_MINUTE,
+			warnings,
+		),
+		rate_limit_mcp_per_minute=_parse_positive_int_env(
+			"MEMORIES_RATE_LIMIT_MCP_PER_MINUTE",
+			DEFAULT_RATE_LIMIT_MCP_PER_MINUTE,
+			warnings,
+		),
+		request_body_max_bytes=_parse_positive_int_env(
+			"MEMORIES_REQUEST_BODY_MAX_BYTES",
+			DEFAULT_REQUEST_BODY_MAX_BYTES,
+			warnings,
+		),
+		warnings=warnings,
+	)
 
 
 def get_database_file_path() -> Path:

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
-from app.config import load_browser_client_config
+from app.config import load_browser_client_config, load_safety_config
 from app.mcp_server import mcp
 from app.schemas import (
 	Memory,
@@ -28,103 +28,106 @@ from app.storage import (
 )
 
 logger = logging.getLogger(__name__)
-browser_client_config = load_browser_client_config()
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-	for warning_message in browser_client_config.warnings:
-		logger.warning(warning_message)
+def create_app() -> FastAPI:
+	browser_client_config = load_browser_client_config()
+	safety_config = load_safety_config()
 
-	async with mcp.session_manager.run():
-		yield
+	@asynccontextmanager
+	async def lifespan(_app: FastAPI):
+		for warning_message in browser_client_config.warnings:
+			logger.warning(warning_message)
+		for warning_message in safety_config.warnings:
+			logger.warning(warning_message)
 
+		async with mcp.session_manager.run():
+			yield
 
-app = FastAPI(title="Memories API", lifespan=lifespan)
-app.add_middleware(
-	CORSMiddleware,
-	allow_origins=browser_client_config.allowed_origins,
-	allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-	allow_headers=[
-		"Content-Type",
-		"Accept",
-		"MCP-Protocol-Version",
-		"Mcp-Session-Id",
-	],
-	expose_headers=["Mcp-Session-Id"],
-)
-
-
-@app.middleware("http")
-async def validate_mcp_browser_origin(request: Request, call_next):
-	origin = request.headers.get("origin")
-	if request.url.path.startswith("/mcp") and origin is not None:
-		if origin not in browser_client_config.allowed_origins:
-			return JSONResponse(status_code=403, content={"detail": "Origin not allowed"})
-
-	return await call_next(request)
-
-
-@app.post("/memories")
-def post_memory(memory: MemoryCreate) -> Memory:
-	return create_memory(memory)
-
-
-@app.post("/memories/batch")
-def post_memory_batch(memories: list[MemoryCreate]) -> list[Memory]:
-	return create_memory_batch(memories)
-
-
-@app.get("/memories")
-def list_memories(query: Annotated[MemoryListQuery, Depends()]) -> MemoryListResponse:
-	paged_memories, total = get_memories_page(query)
-	items = refresh_memories_last_accessed(paged_memories)
-
-	return MemoryListResponse(
-		items=items,
-		total=total,
-		limit=query.limit,
-		offset=query.offset,
-		has_more=query.offset + len(items) < total,
+	application = FastAPI(title="Memories API", lifespan=lifespan)
+	application.state.browser_client_config = browser_client_config
+	application.state.safety_config = safety_config
+	application.add_middleware(
+		CORSMiddleware,
+		allow_origins=browser_client_config.allowed_origins,
+		allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+		allow_headers=[
+			"Content-Type",
+			"Accept",
+			"MCP-Protocol-Version",
+			"Mcp-Session-Id",
+		],
+		expose_headers=["Mcp-Session-Id"],
 	)
 
+	@application.middleware("http")
+	async def validate_mcp_browser_origin(request: Request, call_next):
+		origin = request.headers.get("origin")
+		if request.url.path.startswith("/mcp") and origin is not None:
+			if origin not in browser_client_config.allowed_origins:
+				return JSONResponse(status_code=403, content={"detail": "Origin not allowed"})
 
-@app.get("/memories/{memory_id}")
-def get_memory_by_id(memory_id: int) -> Memory:
-	memory = get_memory(memory_id)
-	if memory is None:
-		raise HTTPException(status_code=404, detail="Memory not found")
-	return memory
+		return await call_next(request)
+
+	@application.post("/memories")
+	def post_memory(memory: MemoryCreate) -> Memory:
+		return create_memory(memory)
+
+	@application.post("/memories/batch")
+	def post_memory_batch(memories: list[MemoryCreate]) -> list[Memory]:
+		return create_memory_batch(memories)
+
+	@application.get("/memories")
+	def list_memories(query: Annotated[MemoryListQuery, Depends()]) -> MemoryListResponse:
+		paged_memories, total = get_memories_page(query)
+		items = refresh_memories_last_accessed(paged_memories)
+
+		return MemoryListResponse(
+			items=items,
+			total=total,
+			limit=query.limit,
+			offset=query.offset,
+			has_more=query.offset + len(items) < total,
+		)
+
+	@application.get("/memories/{memory_id}")
+	def get_memory_by_id(memory_id: int) -> Memory:
+		memory = get_memory(memory_id)
+		if memory is None:
+			raise HTTPException(status_code=404, detail="Memory not found")
+		return memory
+
+	@application.patch("/memories/{memory_id}")
+	def patch_memory_by_id(memory_id: int, memory: MemoryUpdate) -> Memory:
+		try:
+			updated_memory = update_memory(memory_id, memory)
+		except MemoryWriteConflictError as error:
+			raise HTTPException(
+				status_code=409,
+				detail="Memory was modified by another request",
+			) from error
+
+		if updated_memory is None:
+			raise HTTPException(status_code=404, detail="Memory not found")
+		return updated_memory
+
+	@application.delete("/memories/{memory_id}")
+	def delete_memory_by_id(memory_id: int) -> Memory:
+		try:
+			deleted_memory = delete_memory(memory_id)
+		except MemoryWriteConflictError as error:
+			raise HTTPException(
+				status_code=409,
+				detail="Memory was modified by another request",
+			) from error
+
+		if deleted_memory is None:
+			raise HTTPException(status_code=404, detail="Memory not found")
+		return deleted_memory
+
+	application.mount("/mcp", mcp.streamable_http_app())
+
+	return application
 
 
-@app.patch("/memories/{memory_id}")
-def patch_memory_by_id(memory_id: int, memory: MemoryUpdate) -> Memory:
-	try:
-		updated_memory = update_memory(memory_id, memory)
-	except MemoryWriteConflictError as error:
-		raise HTTPException(
-			status_code=409,
-			detail="Memory was modified by another request",
-		) from error
-
-	if updated_memory is None:
-		raise HTTPException(status_code=404, detail="Memory not found")
-	return updated_memory
-
-
-@app.delete("/memories/{memory_id}")
-def delete_memory_by_id(memory_id: int) -> Memory:
-	try:
-		deleted_memory = delete_memory(memory_id)
-	except MemoryWriteConflictError as error:
-		raise HTTPException(
-			status_code=409,
-			detail="Memory was modified by another request",
-		) from error
-
-	if deleted_memory is None:
-		raise HTTPException(status_code=404, detail="Memory not found")
-	return deleted_memory
-
-
-app.mount("/mcp", mcp.streamable_http_app())
+app = create_app()

--- a/app/main.py
+++ b/app/main.py
@@ -3,13 +3,17 @@ from contextlib import asynccontextmanager
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 from starlette.requests import Request
 
 from app.config import load_browser_client_config, load_safety_config
 from app.mcp_server import mcp
 from app.schemas import (
+	DEFAULT_PAGE_LIMIT,
+	MAX_BATCH_CREATE_MEMORIES,
 	Memory,
 	MemoryCreate,
 	MemoryListQuery,
@@ -28,6 +32,43 @@ from app.storage import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _query_validation_errors(error: ValidationError) -> list[dict]:
+	errors: list[dict] = []
+	for validation_error in error.errors():
+		query_error = validation_error.copy()
+		query_error["loc"] = ("query", *validation_error["loc"])
+		if "ctx" in query_error and "error" in query_error["ctx"]:
+			query_error["ctx"] = {
+				**query_error["ctx"],
+				"error": str(query_error["ctx"]["error"]),
+			}
+		errors.append(query_error)
+	return errors
+
+
+def build_memory_list_query(
+	status: str | None = None,
+	memory_type: str | None = None,
+	tag: str | None = None,
+	q: str | None = None,
+	sort: str = "id",
+	limit: int = DEFAULT_PAGE_LIMIT,
+	offset: int = 0,
+) -> MemoryListQuery:
+	try:
+		return MemoryListQuery(
+			status=status,
+			memory_type=memory_type,
+			tag=tag,
+			q=q,
+			sort=sort,
+			limit=limit,
+			offset=offset,
+		)
+	except ValidationError as error:
+		raise RequestValidationError(_query_validation_errors(error)) from error
 
 
 def create_app() -> FastAPI:
@@ -75,10 +116,17 @@ def create_app() -> FastAPI:
 
 	@application.post("/memories/batch")
 	def post_memory_batch(memories: list[MemoryCreate]) -> list[Memory]:
+		if len(memories) > MAX_BATCH_CREATE_MEMORIES:
+			raise HTTPException(
+				status_code=422,
+				detail=f"Batch create is limited to {MAX_BATCH_CREATE_MEMORIES} memories",
+			)
 		return create_memory_batch(memories)
 
 	@application.get("/memories")
-	def list_memories(query: Annotated[MemoryListQuery, Depends()]) -> MemoryListResponse:
+	def list_memories(
+		query: Annotated[MemoryListQuery, Depends(build_memory_list_query)],
+	) -> MemoryListResponse:
 		paged_memories, total = get_memories_page(query)
 		items = refresh_memories_last_accessed(paged_memories)
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 
 from app.config import load_browser_client_config, load_safety_config
 from app.mcp_server import mcp
+from app.request_limits import reject_request_body_if_too_large
 from app.schemas import (
 	DEFAULT_PAGE_LIMIT,
 	MAX_BATCH_CREATE_MEMORIES,
@@ -102,7 +103,14 @@ def create_app() -> FastAPI:
 	)
 
 	@application.middleware("http")
-	async def validate_mcp_browser_origin(request: Request, call_next):
+	async def enforce_request_safety(request: Request, call_next):
+		body_limit_response = reject_request_body_if_too_large(
+			request,
+			safety_config.request_body_max_bytes,
+		)
+		if body_limit_response is not None:
+			return body_limit_response
+
 		origin = request.headers.get("origin")
 		if request.url.path.startswith("/mcp") and origin is not None:
 			if origin not in browser_client_config.allowed_origins:

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,11 @@ from starlette.requests import Request
 
 from app.config import load_browser_client_config, load_safety_config
 from app.mcp_server import mcp
-from app.request_limits import reject_request_body_if_too_large
+from app.request_limits import (
+	FixedWindowRateLimiter,
+	reject_request_body_if_too_large,
+	reject_request_if_rate_limited,
+)
 from app.schemas import (
 	DEFAULT_PAGE_LIMIT,
 	MAX_BATCH_CREATE_MEMORIES,
@@ -89,6 +93,7 @@ def create_app() -> FastAPI:
 	application = FastAPI(title="Memories API", lifespan=lifespan)
 	application.state.browser_client_config = browser_client_config
 	application.state.safety_config = safety_config
+	application.state.rate_limiter = FixedWindowRateLimiter()
 	application.add_middleware(
 		CORSMiddleware,
 		allow_origins=browser_client_config.allowed_origins,
@@ -98,8 +103,16 @@ def create_app() -> FastAPI:
 			"Accept",
 			"MCP-Protocol-Version",
 			"Mcp-Session-Id",
+			"X-Client-Id",
 		],
-		expose_headers=["Mcp-Session-Id"],
+		expose_headers=[
+			"Mcp-Session-Id",
+			"Retry-After",
+			"X-RateLimit-Limit",
+			"X-RateLimit-Remaining",
+			"X-RateLimit-Reset",
+			"X-Request-Body-Limit",
+		],
 	)
 
 	@application.middleware("http")
@@ -110,6 +123,14 @@ def create_app() -> FastAPI:
 		)
 		if body_limit_response is not None:
 			return body_limit_response
+
+		rate_limit_response = reject_request_if_rate_limited(
+			request,
+			application.state.rate_limiter,
+			safety_config,
+		)
+		if rate_limit_response is not None:
+			return rate_limit_response
 
 		origin = request.headers.get("origin")
 		if request.url.path.startswith("/mcp") and origin is not None:

--- a/app/request_limits.py
+++ b/app/request_limits.py
@@ -1,0 +1,45 @@
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
+
+BODY_LIMITED_METHODS = {"POST", "PATCH"}
+REQUEST_BODY_LIMIT_HEADER = "X-Request-Body-Limit"
+
+
+def request_body_limit_applies(request: Request) -> bool:
+	if request.method.upper() not in BODY_LIMITED_METHODS:
+		return False
+
+	path = request.url.path
+	return path == "/memories" or path.startswith("/memories/") or path.startswith("/mcp")
+
+
+def declared_content_length(request: Request) -> int | None:
+	header_value = request.headers.get("content-length")
+	if header_value is None:
+		return None
+
+	try:
+		content_length = int(header_value)
+	except ValueError:
+		return None
+
+	if content_length < 0:
+		return None
+
+	return content_length
+
+
+def reject_request_body_if_too_large(request: Request, max_body_bytes: int) -> JSONResponse | None:
+	content_length = declared_content_length(request)
+	if (
+		content_length is not None
+		and request_body_limit_applies(request)
+		and content_length > max_body_bytes
+	):
+		return JSONResponse(
+			status_code=413,
+			content={"detail": "Request body too large"},
+			headers={REQUEST_BODY_LIMIT_HEADER: str(max_body_bytes)},
+		)
+
+	return None

--- a/app/request_limits.py
+++ b/app/request_limits.py
@@ -1,8 +1,40 @@
+import math
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
+from app.config import SafetyConfig
+
 BODY_LIMITED_METHODS = {"POST", "PATCH"}
 REQUEST_BODY_LIMIT_HEADER = "X-Request-Body-Limit"
+RATE_LIMIT_WINDOW_SECONDS = 60
+RATE_LIMIT_CLIENT_ID_HEADER = "X-Client-Id"
+RATE_LIMIT_CLIENT_ID_MAX_CHARS = 128
+
+
+@dataclass(frozen=True)
+class RateLimitBucket:
+	name: str
+	limit: int
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+	allowed: bool
+	limit: int
+	remaining: int
+	reset_epoch: int
+	retry_after_seconds: int
+
+
+@dataclass
+class _RateLimitWindow:
+	count: int
+	reset_monotonic: float
+	reset_epoch: int
 
 
 def request_body_limit_applies(request: Request) -> bool:
@@ -43,3 +75,130 @@ def reject_request_body_if_too_large(request: Request, max_body_bytes: int) -> J
 		)
 
 	return None
+
+
+class FixedWindowRateLimiter:
+	def __init__(
+		self,
+		*,
+		monotonic_clock: Callable[[], float] = time.monotonic,
+		wall_clock: Callable[[], float] = time.time,
+	) -> None:
+		self._monotonic_clock = monotonic_clock
+		self._wall_clock = wall_clock
+		self._windows: dict[tuple[str, str], _RateLimitWindow] = {}
+
+	def check(self, *, identity: str, bucket: str, limit: int) -> RateLimitDecision:
+		now = self._monotonic_clock()
+		self._prune_expired_windows(now)
+
+		key = (identity, bucket)
+		window = self._windows.get(key)
+		if window is None:
+			window = _RateLimitWindow(
+				count=0,
+				reset_monotonic=now + RATE_LIMIT_WINDOW_SECONDS,
+				reset_epoch=math.ceil(self._wall_clock() + RATE_LIMIT_WINDOW_SECONDS),
+			)
+			self._windows[key] = window
+
+		retry_after_seconds = max(1, math.ceil(window.reset_monotonic - now))
+		if window.count >= limit:
+			return RateLimitDecision(
+				allowed=False,
+				limit=limit,
+				remaining=0,
+				reset_epoch=window.reset_epoch,
+				retry_after_seconds=retry_after_seconds,
+			)
+
+		window.count += 1
+		return RateLimitDecision(
+			allowed=True,
+			limit=limit,
+			remaining=max(0, limit - window.count),
+			reset_epoch=window.reset_epoch,
+			retry_after_seconds=retry_after_seconds,
+		)
+
+	def _prune_expired_windows(self, now: float) -> None:
+		expired_keys = [
+			key for key, window in self._windows.items() if window.reset_monotonic <= now
+		]
+		for key in expired_keys:
+			del self._windows[key]
+
+
+def rate_limit_identity(request: Request) -> str:
+	client_id = request.headers.get(RATE_LIMIT_CLIENT_ID_HEADER)
+	if client_id is not None:
+		normalized_client_id = client_id.strip()
+		if normalized_client_id:
+			return normalized_client_id[:RATE_LIMIT_CLIENT_ID_MAX_CHARS]
+
+	if request.client is not None and request.client.host:
+		return request.client.host
+
+	return "unknown"
+
+
+def classify_rate_limit_bucket(
+	request: Request,
+	safety_config: SafetyConfig,
+) -> RateLimitBucket | None:
+	method = request.method.upper()
+	if method in {"HEAD", "OPTIONS"}:
+		return None
+
+	path = request.url.path
+	if path.startswith("/mcp"):
+		return RateLimitBucket("mcp", safety_config.rate_limit_mcp_per_minute)
+
+	if method == "GET":
+		if path == "/memories" or path.startswith("/memories/"):
+			return RateLimitBucket("reads", safety_config.rate_limit_reads_per_minute)
+		return None
+
+	if method == "POST":
+		if path == "/memories/batch":
+			return RateLimitBucket("batch", safety_config.rate_limit_batch_per_minute)
+		if path == "/memories":
+			return RateLimitBucket("writes", safety_config.rate_limit_writes_per_minute)
+		return None
+
+	if method in {"PATCH", "DELETE"} and path.startswith("/memories/"):
+		return RateLimitBucket("writes", safety_config.rate_limit_writes_per_minute)
+
+	return None
+
+
+def reject_request_if_rate_limited(
+	request: Request,
+	limiter: FixedWindowRateLimiter,
+	safety_config: SafetyConfig,
+) -> JSONResponse | None:
+	if not safety_config.rate_limiting_enabled:
+		return None
+
+	bucket = classify_rate_limit_bucket(request, safety_config)
+	if bucket is None:
+		return None
+
+	decision = limiter.check(
+		identity=rate_limit_identity(request),
+		bucket=bucket.name,
+		limit=bucket.limit,
+	)
+	if decision.allowed:
+		return None
+
+	return JSONResponse(
+		status_code=429,
+		content={"detail": "Rate limit exceeded"},
+		headers={
+			"Retry-After": str(decision.retry_after_seconds),
+			"X-RateLimit-Limit": str(decision.limit),
+			"X-RateLimit-Remaining": str(decision.remaining),
+			"X-RateLimit-Reset": str(decision.reset_epoch),
+		},
+	)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -11,6 +11,11 @@ ALLOWED_MEMORY_TYPES = {
 ALLOWED_STATUSES = {"active", "invalid", "deleted"}
 DEFAULT_PAGE_LIMIT = 10
 MAX_PAGE_LIMIT = 100
+MAX_MEMORY_CONTENT_CHARS = 8_000
+MAX_MEMORY_TAGS = 20
+MAX_MEMORY_TAG_CHARS = 64
+MAX_TEXT_FILTER_CHARS = 256
+MAX_BATCH_CREATE_MEMORIES = 25
 ALLOWED_MEMORY_SORTS = {"id", "created_at", "updated_at", "last_accessed_at"}
 
 
@@ -19,6 +24,8 @@ def validate_content_value(value: str) -> str:
 		raise ValueError("content must be a string")
 	if not value.strip():
 		raise ValueError("content cannot be empty")
+	if len(value) > MAX_MEMORY_CONTENT_CHARS:
+		raise ValueError(f"content cannot exceed {MAX_MEMORY_CONTENT_CHARS} characters")
 	return value
 
 
@@ -27,11 +34,15 @@ def validate_tags_value(value: list[str]) -> list[str]:
 		raise ValueError("tags must be a list of strings")
 	if not value:
 		raise ValueError("tags cannot be empty")
+	if len(value) > MAX_MEMORY_TAGS:
+		raise ValueError(f"tags cannot contain more than {MAX_MEMORY_TAGS} entries")
 	for tag in value:
 		if not isinstance(tag, str):
 			raise ValueError("each tag must be a string")
 		if not tag.strip():
 			raise ValueError("tags cannot contain empty strings")
+		if len(tag) > MAX_MEMORY_TAG_CHARS:
+			raise ValueError(f"tags cannot exceed {MAX_MEMORY_TAG_CHARS} characters")
 	return value
 
 
@@ -164,6 +175,8 @@ class MemoryListQuery(BaseModel):
 		normalized_value = value.strip()
 		if not normalized_value:
 			raise ValueError("filter cannot be empty")
+		if len(normalized_value) > MAX_TEXT_FILTER_CHARS:
+			raise ValueError(f"filter cannot exceed {MAX_TEXT_FILTER_CHARS} characters")
 		return normalized_value
 
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,112 @@
+# Rate Limit Stress Scripts
+
+This directory contains standalone behavioral stress tests for the Memories API rate limiter.
+These are not pytest tests. They intentionally generate request bursts and timing-sensitive load
+against a running local server.
+
+The script focuses on the four scenarios agreed for realistic agent use and overload behavior:
+
+- `mixed`: a normal mixed agent workload. For REST, this combines reads, writes, and batch writes
+  at a paced interval. For MCP, this sends paced MCP HTTP requests. This replaces a separate
+  "normal session" test and gives a practical baseline for expected agent usage.
+- `fast`: a single agent making requests as fast as possible. For REST, it sends read and write
+  requests with no delay. For MCP, it sends MCP HTTP requests with no delay.
+- `flood`: a concurrent burst from one client. This models a broken loop, runaway agent, or many
+  parallel tool calls.
+- `two-agent`: a normal client and a runaway client at the same time using different
+  `X-Client-Id` values. This checks that a flooded client identity does not consume another
+  client's quota.
+
+Each scenario can run against both surfaces:
+
+- `rest`: memory HTTP routes such as `GET /memories`, `POST /memories`, and
+  `POST /memories/batch`.
+- `mcp`: the MCP streamable HTTP endpoint under `/mcp/`.
+
+For MCP, the stress script sends lightweight `POST /mcp/` requests. The rate limiter runs before
+MCP transport parsing, so these requests are enough to test rate-limit accept/deny behavior without
+implementing a full MCP client handshake. The report treats any non-`429` status as accepted by the
+limiter.
+
+## Run
+
+Start the API against a disposable database:
+
+```powershell
+$env:MEMORIES_DB_FILE="$env:TEMP\memories-rate-limit-stress.db"
+uvicorn app.main:app --host 127.0.0.1 --port 8000
+```
+
+In another shell:
+
+```powershell
+python scripts\rate_limit_stress.py
+```
+
+The script writes an HTML report to `scripts\rate_limit_report.html` by default. The report includes
+summary totals, per-scenario accepted and denied counts, raw status counts, and simple distribution
+bars.
+
+## Useful Options
+
+Run only REST:
+
+```powershell
+python scripts\rate_limit_stress.py --surfaces rest
+```
+
+Run only MCP:
+
+```powershell
+python scripts\rate_limit_stress.py --surfaces mcp
+```
+
+Run selected scenarios:
+
+```powershell
+python scripts\rate_limit_stress.py --scenarios mixed,fast
+```
+
+Point at a different server:
+
+```powershell
+python scripts\rate_limit_stress.py --base-url http://127.0.0.1:8010
+```
+
+Write the report somewhere else:
+
+```powershell
+python scripts\rate_limit_stress.py --output reports\rate-limit-smoke.html
+```
+
+Lower the API limits before starting the server to make denials happen quickly:
+
+```powershell
+$env:MEMORIES_RATE_LIMIT_READS_PER_MINUTE="5"
+$env:MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE="3"
+$env:MEMORIES_RATE_LIMIT_BATCH_PER_MINUTE="2"
+$env:MEMORIES_RATE_LIMIT_MCP_PER_MINUTE="10"
+uvicorn app.main:app --host 127.0.0.1 --port 8000
+```
+
+Tune request counts:
+
+```powershell
+python scripts\rate_limit_stress.py `
+  --fast-rest-reads 200 `
+  --fast-rest-writes 60 `
+  --flood-rest-reads 750 `
+  --flood-mcp-requests 750
+```
+
+## Interpreting Results
+
+For the `mixed` scenario, the expected result is usually zero `429` responses with the default
+limits. That means routine agent memory usage fits comfortably.
+
+For `fast` and `flood`, `429` responses are expected once the configured bucket is exhausted. The
+important signs are that the server remains responsive, the accepted count is near the configured
+per-minute bucket limit, and denials are clean `429`s.
+
+For `two-agent`, the normal client should continue to avoid `429`s while the runaway client is
+limited. That indicates `X-Client-Id` isolation is behaving as intended under load.

--- a/scripts/rate_limit_stress.py
+++ b/scripts/rate_limit_stress.py
@@ -1,0 +1,779 @@
+"""Behavioral rate-limit stress scenarios for the local Memories API.
+
+Run this against a disposable local server, for example:
+
+    $env:MEMORIES_DB_FILE="$env:TEMP\\memories-rate-limit-stress.db"
+    uvicorn app.main:app --host 127.0.0.1 --port 8000
+
+Then:
+
+    python scripts/rate_limit_stress.py
+
+The scenarios intentionally live outside pytest because they are timing-sensitive and
+generate load. They focus on realistic agent usage, fast agent bursts, concurrent floods,
+and client isolation across REST and MCP HTTP surfaces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import collections
+import dataclasses
+import html
+import random
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+
+REST_SURFACE = "rest"
+MCP_SURFACE = "mcp"
+DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+
+
+@dataclass(frozen=True)
+class LoadProfile:
+	mixed_rest_reads: int = 40
+	mixed_rest_writes: int = 8
+	mixed_rest_batches: int = 2
+	mixed_mcp_requests: int = 80
+	mixed_pause_seconds: float = 0.15
+	fast_rest_reads: int = 150
+	fast_rest_writes: int = 40
+	fast_mcp_requests: int = 300
+	flood_rest_reads: int = 500
+	flood_rest_writes: int = 100
+	flood_mcp_requests: int = 500
+	two_agent_normal_rest_reads: int = 40
+	two_agent_normal_rest_writes: int = 6
+	two_agent_normal_mcp_requests: int = 60
+	two_agent_flood_rest_reads: int = 300
+	two_agent_flood_mcp_requests: int = 300
+
+
+@dataclass(frozen=True)
+class StressConfig:
+	base_url: str
+	timeout_seconds: float
+	profile: LoadProfile
+	scenarios: tuple[str, ...]
+	surfaces: tuple[str, ...]
+	output_file: Path
+
+
+@dataclass(frozen=True)
+class RequestSpec:
+	method: str
+	path: str
+	json: object | None = None
+
+
+@dataclass
+class ScenarioResult:
+	scenario: str
+	surface: str
+	client_id: str
+	duration_seconds: float
+	status_counts: collections.Counter[int]
+
+	@property
+	def accepted_by_limiter(self) -> int:
+		return sum(count for status, count in self.status_counts.items() if status != 429)
+
+	@property
+	def denied_by_limiter(self) -> int:
+		return self.status_counts[429]
+
+	@property
+	def other_errors(self) -> int:
+		return sum(
+			count
+			for status, count in self.status_counts.items()
+			if status >= 500 or status in {408, 409}
+		)
+
+	@property
+	def total_requests(self) -> int:
+		return sum(self.status_counts.values())
+
+	@property
+	def denied_percent(self) -> float:
+		if self.total_requests == 0:
+			return 0
+		return self.denied_by_limiter / self.total_requests * 100
+
+
+async def send_request(
+	client: httpx.AsyncClient,
+	spec: RequestSpec,
+	client_id: str,
+) -> int:
+	response = await client.request(
+		spec.method,
+		spec.path,
+		headers={"X-Client-Id": client_id},
+		json=spec.json,
+	)
+	return response.status_code
+
+
+def rest_read_spec() -> RequestSpec:
+	return RequestSpec("GET", "/memories", None)
+
+
+def rest_write_spec(index: int) -> RequestSpec:
+	return RequestSpec(
+		"POST",
+		"/memories",
+		{
+			"content": f"rate limit stress memory {time.time_ns()} {index}",
+			"tags": ["stress", "rate-limit"],
+		},
+	)
+
+
+def rest_batch_spec(index: int) -> RequestSpec:
+	return RequestSpec(
+		"POST",
+		"/memories/batch",
+		[
+			{
+				"content": f"rate limit stress batch memory {time.time_ns()} {index}",
+				"tags": ["stress", "batch"],
+			}
+		],
+	)
+
+
+def mcp_request_spec() -> RequestSpec:
+	return RequestSpec("POST", "/mcp/", {})
+
+
+def mixed_rest_specs(profile: LoadProfile) -> list[RequestSpec]:
+	specs: list[RequestSpec] = []
+	for index in range(max(profile.mixed_rest_reads, profile.mixed_rest_writes)):
+		if index < profile.mixed_rest_writes:
+			specs.append(rest_write_spec(index))
+		if index < profile.mixed_rest_batches:
+			specs.append(rest_batch_spec(index))
+		if index < profile.mixed_rest_reads:
+			specs.append(rest_read_spec())
+	return specs
+
+
+def mixed_mcp_specs(profile: LoadProfile) -> list[RequestSpec]:
+	return [mcp_request_spec() for _ in range(profile.mixed_mcp_requests)]
+
+
+def fast_rest_specs(profile: LoadProfile) -> list[RequestSpec]:
+	return [
+		*[rest_read_spec() for _ in range(profile.fast_rest_reads)],
+		*[rest_write_spec(index) for index in range(profile.fast_rest_writes)],
+	]
+
+
+def fast_mcp_specs(profile: LoadProfile) -> list[RequestSpec]:
+	return [mcp_request_spec() for _ in range(profile.fast_mcp_requests)]
+
+
+def flood_rest_specs(profile: LoadProfile) -> list[RequestSpec]:
+	return [
+		*[rest_read_spec() for _ in range(profile.flood_rest_reads)],
+		*[rest_write_spec(index) for index in range(profile.flood_rest_writes)],
+	]
+
+
+def flood_mcp_specs(profile: LoadProfile) -> list[RequestSpec]:
+	return [mcp_request_spec() for _ in range(profile.flood_mcp_requests)]
+
+
+async def run_sequence(
+	client: httpx.AsyncClient,
+	specs: list[RequestSpec],
+	client_id: str,
+	pause_seconds: float,
+) -> collections.Counter[int]:
+	statuses: collections.Counter[int] = collections.Counter()
+	for spec in specs:
+		statuses[await send_request(client, spec, client_id)] += 1
+		if pause_seconds > 0:
+			await asyncio.sleep(pause_seconds)
+	return statuses
+
+
+async def run_concurrent(
+	client: httpx.AsyncClient,
+	specs: list[RequestSpec],
+	client_id: str,
+) -> collections.Counter[int]:
+	statuses = await asyncio.gather(
+		*(send_request(client, spec, client_id) for spec in specs),
+	)
+	return collections.Counter(statuses)
+
+
+async def run_single_result(
+	config: StressConfig,
+	scenario: str,
+	surface: str,
+	client_id: str,
+	specs: list[RequestSpec],
+	runner: Callable[
+		[httpx.AsyncClient, list[RequestSpec], str], Awaitable[collections.Counter[int]]
+	],
+) -> ScenarioResult:
+	timeout = httpx.Timeout(config.timeout_seconds)
+	limits = httpx.Limits(max_connections=max(100, len(specs)), max_keepalive_connections=50)
+	async with httpx.AsyncClient(
+		base_url=config.base_url,
+		timeout=timeout,
+		limits=limits,
+	) as client:
+		started = time.perf_counter()
+		status_counts = await runner(client, specs, client_id)
+		duration_seconds = time.perf_counter() - started
+
+	return ScenarioResult(
+		scenario=scenario,
+		surface=surface,
+		client_id=client_id,
+		duration_seconds=duration_seconds,
+		status_counts=status_counts,
+	)
+
+
+async def run_mixed_workload(config: StressConfig, surface: str) -> list[ScenarioResult]:
+	profile = config.profile
+	client_id = f"stress-mixed-{surface}-{random.randrange(1_000_000)}"
+	if surface == REST_SURFACE:
+		specs = mixed_rest_specs(profile)
+	else:
+		specs = mixed_mcp_specs(profile)
+
+	async def paced_runner(
+		client: httpx.AsyncClient,
+		request_specs: list[RequestSpec],
+		request_client_id: str,
+	) -> collections.Counter[int]:
+		return await run_sequence(
+			client,
+			request_specs,
+			request_client_id,
+			profile.mixed_pause_seconds,
+		)
+
+	return [
+		await run_single_result(
+			config,
+			"mixed_workload",
+			surface,
+			client_id,
+			specs,
+			paced_runner,
+		)
+	]
+
+
+async def run_fast_agent(config: StressConfig, surface: str) -> list[ScenarioResult]:
+	profile = config.profile
+	client_id = f"stress-fast-{surface}-{random.randrange(1_000_000)}"
+	specs = fast_rest_specs(profile) if surface == REST_SURFACE else fast_mcp_specs(profile)
+	return [
+		await run_single_result(
+			config,
+			"fast_agent",
+			surface,
+			client_id,
+			specs,
+			run_sequence_no_pause,
+		)
+	]
+
+
+async def run_concurrent_flood(config: StressConfig, surface: str) -> list[ScenarioResult]:
+	profile = config.profile
+	client_id = f"stress-flood-{surface}-{random.randrange(1_000_000)}"
+	specs = flood_rest_specs(profile) if surface == REST_SURFACE else flood_mcp_specs(profile)
+	return [
+		await run_single_result(
+			config,
+			"concurrent_flood",
+			surface,
+			client_id,
+			specs,
+			run_concurrent,
+		)
+	]
+
+
+async def run_two_agent_comparison(config: StressConfig, surface: str) -> list[ScenarioResult]:
+	profile = config.profile
+	normal_client_id = f"stress-normal-{surface}-{random.randrange(1_000_000)}"
+	flood_client_id = f"stress-runaway-{surface}-{random.randrange(1_000_000)}"
+
+	if surface == REST_SURFACE:
+		normal_specs = [
+			*[rest_read_spec() for _ in range(profile.two_agent_normal_rest_reads)],
+			*[rest_write_spec(index) for index in range(profile.two_agent_normal_rest_writes)],
+		]
+		flood_specs = [
+			*[rest_read_spec() for _ in range(profile.two_agent_flood_rest_reads)],
+		]
+	else:
+		normal_specs = [mcp_request_spec() for _ in range(profile.two_agent_normal_mcp_requests)]
+		flood_specs = [mcp_request_spec() for _ in range(profile.two_agent_flood_mcp_requests)]
+
+	async with httpx.AsyncClient(
+		base_url=config.base_url,
+		timeout=httpx.Timeout(config.timeout_seconds),
+		limits=httpx.Limits(max_connections=500, max_keepalive_connections=100),
+	) as client:
+		started = time.perf_counter()
+		normal_task = asyncio.create_task(
+			run_sequence(client, normal_specs, normal_client_id, profile.mixed_pause_seconds)
+		)
+		flood_task = asyncio.create_task(run_concurrent(client, flood_specs, flood_client_id))
+		normal_counts, flood_counts = await asyncio.gather(normal_task, flood_task)
+		duration_seconds = time.perf_counter() - started
+
+	return [
+		ScenarioResult(
+			scenario="two_agent_comparison_normal",
+			surface=surface,
+			client_id=normal_client_id,
+			duration_seconds=duration_seconds,
+			status_counts=normal_counts,
+		),
+		ScenarioResult(
+			scenario="two_agent_comparison_runaway",
+			surface=surface,
+			client_id=flood_client_id,
+			duration_seconds=duration_seconds,
+			status_counts=flood_counts,
+		),
+	]
+
+
+async def run_sequence_no_pause(
+	client: httpx.AsyncClient,
+	specs: list[RequestSpec],
+	client_id: str,
+) -> collections.Counter[int]:
+	return await run_sequence(client, specs, client_id, 0)
+
+
+SCENARIO_RUNNERS = {
+	"mixed": run_mixed_workload,
+	"fast": run_fast_agent,
+	"flood": run_concurrent_flood,
+	"two-agent": run_two_agent_comparison,
+}
+
+
+async def run_stress_suite(config: StressConfig) -> list[ScenarioResult]:
+	results: list[ScenarioResult] = []
+	for scenario in config.scenarios:
+		for surface in config.surfaces:
+			results.extend(await SCENARIO_RUNNERS[scenario](config, surface))
+	return results
+
+
+def status_badge_class(status: int) -> str:
+	if status == 429:
+		return "status-denied"
+	if status >= 500 or status in {408, 409}:
+		return "status-error"
+	return "status-accepted"
+
+
+def html_escape(value: object) -> str:
+	return html.escape(str(value), quote=True)
+
+
+def render_status_badges(status_counts: collections.Counter[int]) -> str:
+	return "".join(
+		f'<span class="status-badge {status_badge_class(status)}">'
+		f"{html_escape(status)}: {html_escape(count)}</span>"
+		for status, count in sorted(status_counts.items())
+	)
+
+
+def render_bar(result: ScenarioResult) -> str:
+	total = max(1, result.total_requests)
+	accepted_width = result.accepted_by_limiter / total * 100
+	denied_width = result.denied_by_limiter / total * 100
+	other_width = max(0, 100 - accepted_width - denied_width)
+	return (
+		'<div class="bar" aria-label="request outcome distribution">'
+		f'<div class="bar-accepted" style="width: {accepted_width:.2f}%"></div>'
+		f'<div class="bar-denied" style="width: {denied_width:.2f}%"></div>'
+		f'<div class="bar-other" style="width: {other_width:.2f}%"></div>'
+		"</div>"
+	)
+
+
+def render_html_report(config: StressConfig, results: list[ScenarioResult]) -> str:
+	total_requests = sum(result.total_requests for result in results)
+	total_accepted = sum(result.accepted_by_limiter for result in results)
+	total_denied = sum(result.denied_by_limiter for result in results)
+	total_other = sum(result.other_errors for result in results)
+	generated_at = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+
+	rows = []
+	for result in results:
+		rows.append(
+			f"""
+			<tr>
+				<td>
+					<strong>{html_escape(result.scenario)}</strong>
+					<div class="muted">{html_escape(result.client_id)}</div>
+				</td>
+				<td><span class="surface">{html_escape(result.surface)}</span></td>
+				<td class="numeric">{result.total_requests}</td>
+				<td class="numeric accepted">{result.accepted_by_limiter}</td>
+				<td class="numeric denied">{result.denied_by_limiter}</td>
+				<td class="numeric">{result.denied_percent:.1f}%</td>
+				<td class="numeric">{result.other_errors}</td>
+				<td class="numeric">{result.duration_seconds:.2f}s</td>
+				<td>{render_bar(result)}</td>
+				<td class="statuses">{render_status_badges(result.status_counts)}</td>
+			</tr>
+			"""
+		)
+
+	return f"""<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Memories API Rate Limit Stress Report</title>
+	<style>
+		:root {{
+			color-scheme: light;
+			--bg: #f6f7f9;
+			--panel: #ffffff;
+			--ink: #17202a;
+			--muted: #667085;
+			--line: #d9dee7;
+			--accepted: #16835f;
+			--accepted-bg: #dff5ec;
+			--denied: #b42318;
+			--denied-bg: #fee4df;
+			--other: #875bf7;
+			--other-bg: #eee8ff;
+			--surface: #1f6feb;
+			--surface-bg: #e7f0ff;
+		}}
+
+		body {{
+			margin: 0;
+			background: var(--bg);
+			color: var(--ink);
+			font-family:
+				Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+				sans-serif;
+		}}
+
+		main {{
+			max-width: 1180px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}}
+
+		header {{
+			margin-bottom: 24px;
+		}}
+
+		h1 {{
+			margin: 0 0 8px;
+			font-size: 28px;
+			line-height: 1.2;
+		}}
+
+		.meta {{
+			display: flex;
+			flex-wrap: wrap;
+			gap: 10px 18px;
+			color: var(--muted);
+			font-size: 14px;
+		}}
+
+		.cards {{
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin: 20px 0 24px;
+		}}
+
+		.card {{
+			background: var(--panel);
+			border: 1px solid var(--line);
+			border-radius: 8px;
+			padding: 16px;
+		}}
+
+		.card .label {{
+			color: var(--muted);
+			font-size: 13px;
+			margin-bottom: 8px;
+		}}
+
+		.card .value {{
+			font-size: 26px;
+			font-weight: 700;
+		}}
+
+		.table-wrap {{
+			overflow-x: auto;
+			background: var(--panel);
+			border: 1px solid var(--line);
+			border-radius: 8px;
+		}}
+
+		table {{
+			width: 100%;
+			border-collapse: collapse;
+			min-width: 1020px;
+		}}
+
+		th, td {{
+			padding: 12px 14px;
+			border-bottom: 1px solid var(--line);
+			text-align: left;
+			vertical-align: middle;
+			font-size: 14px;
+		}}
+
+		th {{
+			background: #eef1f6;
+			color: #344054;
+			font-size: 12px;
+			text-transform: uppercase;
+			letter-spacing: 0;
+		}}
+
+		tr:last-child td {{
+			border-bottom: 0;
+		}}
+
+		.numeric {{
+			text-align: right;
+			font-variant-numeric: tabular-nums;
+		}}
+
+		.accepted {{
+			color: var(--accepted);
+			font-weight: 700;
+		}}
+
+		.denied {{
+			color: var(--denied);
+			font-weight: 700;
+		}}
+
+		.muted {{
+			color: var(--muted);
+			font-size: 12px;
+			margin-top: 3px;
+		}}
+
+		.surface, .status-badge {{
+			display: inline-flex;
+			align-items: center;
+			border-radius: 999px;
+			padding: 3px 8px;
+			font-size: 12px;
+			font-weight: 700;
+			white-space: nowrap;
+		}}
+
+		.surface {{
+			color: var(--surface);
+			background: var(--surface-bg);
+		}}
+
+		.statuses {{
+			display: flex;
+			flex-wrap: wrap;
+			gap: 6px;
+		}}
+
+		.status-accepted {{
+			color: var(--accepted);
+			background: var(--accepted-bg);
+		}}
+
+		.status-denied {{
+			color: var(--denied);
+			background: var(--denied-bg);
+		}}
+
+		.status-error {{
+			color: var(--other);
+			background: var(--other-bg);
+		}}
+
+		.bar {{
+			display: flex;
+			width: 150px;
+			height: 10px;
+			overflow: hidden;
+			background: #eceff3;
+			border-radius: 999px;
+		}}
+
+		.bar-accepted {{
+			background: var(--accepted);
+		}}
+
+		.bar-denied {{
+			background: var(--denied);
+		}}
+
+		.bar-other {{
+			background: var(--other);
+		}}
+
+		footer {{
+			margin-top: 18px;
+			color: var(--muted);
+			font-size: 13px;
+		}}
+	</style>
+</head>
+<body>
+	<main>
+		<header>
+			<h1>Memories API Rate Limit Stress Report</h1>
+			<div class="meta">
+				<span>Generated: {html_escape(generated_at)}</span>
+				<span>Base URL: {html_escape(config.base_url)}</span>
+				<span>Scenarios: {html_escape(", ".join(config.scenarios))}</span>
+				<span>Surfaces: {html_escape(", ".join(config.surfaces))}</span>
+			</div>
+		</header>
+
+		<section class="cards" aria-label="summary">
+			<div class="card">
+				<div class="label">Total Requests</div>
+				<div class="value">{total_requests}</div>
+			</div>
+			<div class="card">
+				<div class="label">Accepted By Limiter</div>
+				<div class="value accepted">{total_accepted}</div>
+			</div>
+			<div class="card">
+				<div class="label">Denied 429</div>
+				<div class="value denied">{total_denied}</div>
+			</div>
+			<div class="card">
+				<div class="label">Other Notable Errors</div>
+				<div class="value">{total_other}</div>
+			</div>
+		</section>
+
+		<section class="table-wrap" aria-label="scenario results">
+			<table>
+				<thead>
+					<tr>
+						<th>Scenario</th>
+						<th>Surface</th>
+						<th class="numeric">Total</th>
+						<th class="numeric">Accepted</th>
+						<th class="numeric">429</th>
+						<th class="numeric">Denied %</th>
+						<th class="numeric">Other</th>
+						<th class="numeric">Duration</th>
+						<th>Distribution</th>
+						<th>Status Counts</th>
+					</tr>
+				</thead>
+				<tbody>
+					{"".join(rows)}
+				</tbody>
+			</table>
+		</section>
+
+		<footer>
+			For MCP, non-429 statuses mean the request passed the rate limiter. Lightweight MCP
+			probe requests may still be rejected later by MCP transport parsing.
+		</footer>
+	</main>
+</body>
+</html>
+"""
+
+
+def write_html_report(config: StressConfig, results: list[ScenarioResult]) -> None:
+	config.output_file.parent.mkdir(parents=True, exist_ok=True)
+	config.output_file.write_text(render_html_report(config, results), encoding="utf-8")
+
+
+def parse_csv_choices(value: str, allowed: set[str]) -> tuple[str, ...]:
+	choices = tuple(part.strip() for part in value.split(",") if part.strip())
+	unknown = sorted(set(choices) - allowed)
+	if unknown:
+		raise argparse.ArgumentTypeError(f"unknown choices: {', '.join(unknown)}")
+	return choices
+
+
+def build_parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(
+		description="Run behavioral Memories API rate-limit stress scenarios."
+	)
+	parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+	parser.add_argument("--timeout", type=float, default=30.0)
+	parser.add_argument(
+		"--scenarios",
+		default="mixed,fast,flood,two-agent",
+		help="Comma-separated: mixed,fast,flood,two-agent",
+	)
+	parser.add_argument(
+		"--surfaces",
+		default="rest,mcp",
+		help="Comma-separated: rest,mcp",
+	)
+	parser.add_argument(
+		"--output",
+		type=Path,
+		default=Path("scripts/rate_limit_report.html"),
+		help="HTML report output path.",
+	)
+	for field in dataclasses.fields(LoadProfile):
+		default_value = getattr(LoadProfile(), field.name)
+		parser.add_argument(
+			f"--{field.name.replace('_', '-')}",
+			type=type(default_value),
+			default=default_value,
+		)
+	return parser
+
+
+def build_config(args: argparse.Namespace) -> StressConfig:
+	profile_values = {
+		field.name: getattr(args, field.name) for field in dataclasses.fields(LoadProfile)
+	}
+	return StressConfig(
+		base_url=args.base_url.rstrip("/"),
+		timeout_seconds=args.timeout,
+		profile=LoadProfile(**profile_values),
+		scenarios=parse_csv_choices(args.scenarios, set(SCENARIO_RUNNERS)),
+		surfaces=parse_csv_choices(args.surfaces, {REST_SURFACE, MCP_SURFACE}),
+		output_file=args.output,
+	)
+
+
+def main() -> None:
+	parser = build_parser()
+	config = build_config(parser.parse_args())
+	results = asyncio.run(run_stress_suite(config))
+	write_html_report(config, results)
+	print(f"HTML report written to {config.output_file.resolve()}")
+
+
+if __name__ == "__main__":
+	main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,12 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import app
+from app.main import create_app
 
 
 @pytest.fixture
-def client() -> TestClient:
-	return TestClient(app)
+def client(data_file: Path) -> TestClient:
+	return TestClient(create_app())
 
 
 @pytest.fixture(autouse=True)

--- a/tests/contract/test_http_contract.py
+++ b/tests/contract/test_http_contract.py
@@ -7,6 +7,15 @@ from app import main as app_main
 from app import storage
 
 
+def assert_rate_limited(response, limit: int):
+	assert response.status_code == 429
+	assert response.json() == {"detail": "Rate limit exceeded"}
+	assert response.headers["Retry-After"].isdigit()
+	assert response.headers["X-RateLimit-Limit"] == str(limit)
+	assert response.headers["X-RateLimit-Remaining"] == "0"
+	assert response.headers["X-RateLimit-Reset"].isdigit()
+
+
 def test_post_memory_response_matches_public_contract(
 	client: TestClient, data_file: Path, monkeypatch
 ):
@@ -54,6 +63,107 @@ def test_post_memory_rejects_oversized_body_before_json_parsing(monkeypatch, dat
 	assert response.status_code == 413
 	assert response.json() == {"detail": "Request body too large"}
 	assert response.headers["X-Request-Body-Limit"] == "10"
+	assert read_database(data_file) == []
+
+
+def test_post_memory_rate_limit_uses_client_id_identity(monkeypatch, data_file: Path):
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE", "1")
+	test_client = TestClient(app_main.create_app())
+
+	first_response = test_client.post(
+		"/memories",
+		headers={"X-Client-Id": "agent-a"},
+		json={"content": "First write", "tags": ["rate-limit"]},
+	)
+	second_response = test_client.post(
+		"/memories",
+		headers={"X-Client-Id": " agent-a "},
+		json={"content": "Second write", "tags": ["rate-limit"]},
+	)
+	other_client_response = test_client.post(
+		"/memories",
+		headers={"X-Client-Id": "agent-b"},
+		json={"content": "Other client write", "tags": ["rate-limit"]},
+	)
+
+	assert first_response.status_code == 200
+	assert "X-RateLimit-Limit" not in first_response.headers
+	assert_rate_limited(second_response, 1)
+	assert other_client_response.status_code == 200
+	assert len(read_database(data_file)) == 2
+
+
+def test_read_rate_limit_counts_validation_failures(monkeypatch, data_file: Path):
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_READS_PER_MINUTE", "1")
+	test_client = TestClient(app_main.create_app())
+
+	validation_response = test_client.get(
+		"/memories/not-an-int",
+		headers={"X-Client-Id": "reader"},
+	)
+	limited_response = test_client.get(
+		"/memories",
+		headers={"X-Client-Id": "reader"},
+	)
+
+	assert validation_response.status_code == 422
+	assert_rate_limited(limited_response, 1)
+	assert read_database(data_file) == []
+
+
+def test_batch_create_uses_separate_rate_limit_bucket(monkeypatch, data_file: Path):
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_BATCH_PER_MINUTE", "1")
+	test_client = TestClient(app_main.create_app())
+
+	first_response = test_client.post(
+		"/memories/batch",
+		json=[{"content": "First batch", "tags": ["batch"]}],
+	)
+	second_response = test_client.post(
+		"/memories/batch",
+		json=[{"content": "Second batch", "tags": ["batch"]}],
+	)
+
+	assert first_response.status_code == 200
+	assert_rate_limited(second_response, 1)
+	assert len(read_database(data_file)) == 1
+
+
+def test_rate_limiting_can_be_disabled(monkeypatch, data_file: Path):
+	monkeypatch.setenv("MEMORIES_RATE_LIMITING_ENABLED", "false")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE", "1")
+	test_client = TestClient(app_main.create_app())
+
+	first_response = test_client.post(
+		"/memories",
+		json={"content": "First write", "tags": ["rate-limit"]},
+	)
+	second_response = test_client.post(
+		"/memories",
+		json={"content": "Second write", "tags": ["rate-limit"]},
+	)
+
+	assert first_response.status_code == 200
+	assert second_response.status_code == 200
+	assert len(read_database(data_file)) == 2
+
+
+def test_body_size_limit_runs_before_rate_limit(monkeypatch, data_file: Path):
+	monkeypatch.setenv("MEMORIES_REQUEST_BODY_MAX_BYTES", "10")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE", "1")
+	test_client = TestClient(app_main.create_app())
+
+	oversized_response = test_client.post(
+		"/memories",
+		content="x" * 11,
+		headers={"Content-Type": "application/json"},
+	)
+	first_counted_response = test_client.post("/memories", json={})
+	second_counted_response = test_client.post("/memories", json={})
+
+	assert oversized_response.status_code == 413
+	assert first_counted_response.status_code == 422
+	assert_rate_limited(second_counted_response, 1)
 	assert read_database(data_file) == []
 
 

--- a/tests/contract/test_http_contract.py
+++ b/tests/contract/test_http_contract.py
@@ -41,6 +41,38 @@ def test_post_memory_response_matches_public_contract(
 	assert read_database(data_file) == [body]
 
 
+def test_post_memory_rejects_oversized_body_before_json_parsing(monkeypatch, data_file: Path):
+	monkeypatch.setenv("MEMORIES_REQUEST_BODY_MAX_BYTES", "10")
+	test_client = TestClient(app_main.create_app())
+
+	response = test_client.post(
+		"/memories",
+		content="x" * 11,
+		headers={"Content-Type": "application/json"},
+	)
+
+	assert response.status_code == 413
+	assert response.json() == {"detail": "Request body too large"}
+	assert response.headers["X-Request-Body-Limit"] == "10"
+	assert read_database(data_file) == []
+
+
+def test_patch_memory_rejects_oversized_body_before_json_parsing(monkeypatch, data_file: Path):
+	monkeypatch.setenv("MEMORIES_REQUEST_BODY_MAX_BYTES", "10")
+	test_client = TestClient(app_main.create_app())
+
+	response = test_client.patch(
+		"/memories/1",
+		content="x" * 11,
+		headers={"Content-Type": "application/json"},
+	)
+
+	assert response.status_code == 413
+	assert response.json() == {"detail": "Request body too large"}
+	assert response.headers["X-Request-Body-Limit"] == "10"
+	assert read_database(data_file) == []
+
+
 def test_missing_memory_returns_documented_404_shape(client: TestClient, data_file: Path):
 	response = client.get("/memories/999")
 

--- a/tests/contract/test_mcp_http_transport.py
+++ b/tests/contract/test_mcp_http_transport.py
@@ -56,6 +56,21 @@ def test_mcp_http_allows_configured_browser_origin(monkeypatch, tmp_path: Path):
 	assert response.status_code != 404
 
 
+def test_mcp_http_rejects_oversized_body_before_transport_parsing(monkeypatch):
+	monkeypatch.setenv("MEMORIES_REQUEST_BODY_MAX_BYTES", "10")
+	client = TestClient(main_module.create_app())
+
+	response = client.post(
+		"/mcp",
+		content="x" * 11,
+		headers={"Content-Type": "application/json"},
+	)
+
+	assert response.status_code == 413
+	assert response.json() == {"detail": "Request body too large"}
+	assert response.headers["X-Request-Body-Limit"] == "10"
+
+
 def test_mcp_http_allows_valid_origin_when_another_browser_client_is_invalid(
 	monkeypatch, tmp_path: Path
 ):

--- a/tests/contract/test_mcp_http_transport.py
+++ b/tests/contract/test_mcp_http_transport.py
@@ -9,6 +9,12 @@ import app.mcp_server as mcp_server_module
 from app import config as config_module
 
 
+def build_client_with_fresh_mcp():
+	importlib.reload(mcp_server_module)
+	reloaded_main = importlib.reload(main_module)
+	return TestClient(reloaded_main.app)
+
+
 def build_client_with_browser_config(monkeypatch, tmp_path: Path, browser_clients: list[dict]):
 	config_path = tmp_path / "mcp_browser_clients.local.json"
 	config_path.write_text(json.dumps({"browser_clients": browser_clients}), encoding="utf-8")
@@ -54,6 +60,9 @@ def test_mcp_http_allows_configured_browser_origin(monkeypatch, tmp_path: Path):
 
 	assert response.status_code != 403
 	assert response.status_code != 404
+	expose_headers = response.headers["access-control-expose-headers"]
+	assert "X-RateLimit-Limit" in expose_headers
+	assert "X-Request-Body-Limit" in expose_headers
 
 
 def test_mcp_http_rejects_oversized_body_before_transport_parsing(monkeypatch):
@@ -69,6 +78,22 @@ def test_mcp_http_rejects_oversized_body_before_transport_parsing(monkeypatch):
 	assert response.status_code == 413
 	assert response.json() == {"detail": "Request body too large"}
 	assert response.headers["X-Request-Body-Limit"] == "10"
+
+
+def test_mcp_http_rate_limit_returns_stable_429(monkeypatch):
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_MCP_PER_MINUTE", "1")
+
+	with build_client_with_fresh_mcp() as client:
+		first_response = client.post("/mcp/", json={})
+		second_response = client.post("/mcp/", json={})
+
+	assert first_response.status_code != 429
+	assert second_response.status_code == 429
+	assert second_response.json() == {"detail": "Rate limit exceeded"}
+	assert second_response.headers["Retry-After"].isdigit()
+	assert second_response.headers["X-RateLimit-Limit"] == "1"
+	assert second_response.headers["X-RateLimit-Remaining"] == "0"
+	assert second_response.headers["X-RateLimit-Reset"].isdigit()
 
 
 def test_mcp_http_allows_valid_origin_when_another_browser_client_is_invalid(
@@ -103,7 +128,7 @@ def test_mcp_http_allows_mcp_request_headers_for_allowed_origin(monkeypatch, tmp
 			headers={
 				"Origin": "http://localhost:3000",
 				"Access-Control-Request-Method": "POST",
-				"Access-Control-Request-Headers": "MCP-Protocol-Version,Mcp-Session-Id",
+				"Access-Control-Request-Headers": "MCP-Protocol-Version,Mcp-Session-Id,X-Client-Id",
 			},
 		)
 
@@ -111,3 +136,4 @@ def test_mcp_http_allows_mcp_request_headers_for_allowed_origin(monkeypatch, tmp
 	assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
 	assert "MCP-Protocol-Version" in response.headers["access-control-allow-headers"]
 	assert "Mcp-Session-Id" in response.headers["access-control-allow-headers"]
+	assert "X-Client-Id" in response.headers["access-control-allow-headers"]

--- a/tests/integration/test_memories_batch.py
+++ b/tests/integration/test_memories_batch.py
@@ -5,6 +5,7 @@ from helpers.database_helpers import read_database
 from helpers.memory_builders import expected_memory
 
 from app import storage
+from app.schemas import MAX_BATCH_CREATE_MEMORIES
 
 
 def test_post_memory_batch_returns_created_memories_with_defaults(
@@ -123,5 +124,24 @@ def test_post_memory_batch_returns_400_for_invalid_input(client: TestClient, dat
 				"type": "missing",
 			}
 		]
+	}
+	assert read_database(data_file) == []
+
+
+def test_post_memory_batch_rejects_over_batch_limit(client: TestClient, data_file: Path):
+	response = client.post(
+		"/memories/batch",
+		json=[
+			{
+				"content": f"Memory {index}",
+				"tags": [f"tag-{index}"],
+			}
+			for index in range(MAX_BATCH_CREATE_MEMORIES + 1)
+		],
+	)
+
+	assert response.status_code == 422
+	assert response.json() == {
+		"detail": f"Batch create is limited to {MAX_BATCH_CREATE_MEMORIES} memories"
 	}
 	assert read_database(data_file) == []

--- a/tests/integration/test_memories_create.py
+++ b/tests/integration/test_memories_create.py
@@ -5,6 +5,7 @@ from helpers.database_helpers import read_database
 from helpers.memory_builders import expected_memory
 
 from app import storage
+from app.schemas import MAX_MEMORY_CONTENT_CHARS, MAX_MEMORY_TAG_CHARS, MAX_MEMORY_TAGS
 
 
 def test_post_memory_returns_created_memory_with_defaults(
@@ -180,6 +181,43 @@ def test_post_memory_rejects_invalid_status(client: TestClient, data_file: Path)
 	assert any(
 		error["loc"] == ["body", "status"] and "status must be one of" in error["msg"]
 		for error in body["detail"]
+	)
+	assert read_database(data_file) == []
+
+
+def test_post_memory_rejects_content_over_character_limit(client: TestClient, data_file: Path):
+	response = client.post(
+		"/memories",
+		json={
+			"content": "x" * (MAX_MEMORY_CONTENT_CHARS + 1),
+			"tags": ["note"],
+		},
+	)
+
+	assert response.status_code == 422
+	assert any(
+		error["loc"] == ["body", "content"]
+		and f"content cannot exceed {MAX_MEMORY_CONTENT_CHARS} characters" in error["msg"]
+		for error in response.json()["detail"]
+	)
+	assert read_database(data_file) == []
+
+
+def test_post_memory_rejects_tag_limits(client: TestClient, data_file: Path):
+	response = client.post(
+		"/memories",
+		json={
+			"content": "Learning FastAPI testing",
+			"tags": [f"tag-{index}" for index in range(MAX_MEMORY_TAGS)]
+			+ ["x" * (MAX_MEMORY_TAG_CHARS + 1)],
+		},
+	)
+
+	assert response.status_code == 422
+	assert any(
+		error["loc"] == ["body", "tags"]
+		and f"tags cannot contain more than {MAX_MEMORY_TAGS} entries" in error["msg"]
+		for error in response.json()["detail"]
 	)
 	assert read_database(data_file) == []
 

--- a/tests/integration/test_memories_list.py
+++ b/tests/integration/test_memories_list.py
@@ -5,6 +5,7 @@ from helpers.database_helpers import read_database
 from helpers.memory_builders import expected_memory
 
 from app import storage
+from app.schemas import MAX_TEXT_FILTER_CHARS
 
 DEFAULT_LIMIT = 10
 
@@ -331,6 +332,26 @@ def test_get_memories_filters_by_free_text_query_case_insensitively(
 			last_accessed_at=None,
 		),
 	]
+
+
+def test_get_memories_rejects_text_filters_over_character_limit(
+	client: TestClient, data_file: Path
+):
+	response = client.get(
+		"/memories",
+		params={
+			"tag": "x" * (MAX_TEXT_FILTER_CHARS + 1),
+			"q": "y" * (MAX_TEXT_FILTER_CHARS + 1),
+		},
+	)
+
+	assert response.status_code == 422
+	assert any(
+		error["loc"] == ["query", "tag"]
+		and f"filter cannot exceed {MAX_TEXT_FILTER_CHARS} characters" in error["msg"]
+		for error in response.json()["detail"]
+	)
+	assert read_database(data_file) == []
 
 
 def test_get_memories_supports_explicit_sort_options_with_stable_tiebreaker(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,9 +2,16 @@ import json
 from pathlib import Path
 
 from app.config import (
+	DEFAULT_RATE_LIMIT_BATCH_PER_MINUTE,
+	DEFAULT_RATE_LIMIT_MCP_PER_MINUTE,
+	DEFAULT_RATE_LIMIT_READS_PER_MINUTE,
+	DEFAULT_RATE_LIMIT_WRITES_PER_MINUTE,
+	DEFAULT_RATE_LIMITING_ENABLED,
+	DEFAULT_REQUEST_BODY_MAX_BYTES,
 	ROOT_DIR,
 	get_database_file_path,
 	load_browser_client_config,
+	load_safety_config,
 )
 
 
@@ -101,3 +108,60 @@ def test_load_browser_client_config_preserves_valid_origins_when_entries_are_inv
 	assert config.allowed_origins == ["http://localhost:3000"]
 	assert len(config.warnings) == 1
 	assert "browser_clients[1]" in config.warnings[0]
+
+
+def test_load_safety_config_uses_conservative_defaults(monkeypatch):
+	monkeypatch.delenv("MEMORIES_RATE_LIMITING_ENABLED", raising=False)
+	monkeypatch.delenv("MEMORIES_RATE_LIMIT_READS_PER_MINUTE", raising=False)
+	monkeypatch.delenv("MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE", raising=False)
+	monkeypatch.delenv("MEMORIES_RATE_LIMIT_BATCH_PER_MINUTE", raising=False)
+	monkeypatch.delenv("MEMORIES_RATE_LIMIT_MCP_PER_MINUTE", raising=False)
+	monkeypatch.delenv("MEMORIES_REQUEST_BODY_MAX_BYTES", raising=False)
+
+	config = load_safety_config()
+
+	assert config.rate_limiting_enabled is DEFAULT_RATE_LIMITING_ENABLED
+	assert config.rate_limit_reads_per_minute == DEFAULT_RATE_LIMIT_READS_PER_MINUTE
+	assert config.rate_limit_writes_per_minute == DEFAULT_RATE_LIMIT_WRITES_PER_MINUTE
+	assert config.rate_limit_batch_per_minute == DEFAULT_RATE_LIMIT_BATCH_PER_MINUTE
+	assert config.rate_limit_mcp_per_minute == DEFAULT_RATE_LIMIT_MCP_PER_MINUTE
+	assert config.request_body_max_bytes == DEFAULT_REQUEST_BODY_MAX_BYTES
+	assert config.warnings == []
+
+
+def test_load_safety_config_uses_env_overrides(monkeypatch):
+	monkeypatch.setenv("MEMORIES_RATE_LIMITING_ENABLED", "false")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_READS_PER_MINUTE", "5")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE", "6")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_BATCH_PER_MINUTE", "7")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_MCP_PER_MINUTE", "8")
+	monkeypatch.setenv("MEMORIES_REQUEST_BODY_MAX_BYTES", "9")
+
+	config = load_safety_config()
+
+	assert config.rate_limiting_enabled is False
+	assert config.rate_limit_reads_per_minute == 5
+	assert config.rate_limit_writes_per_minute == 6
+	assert config.rate_limit_batch_per_minute == 7
+	assert config.rate_limit_mcp_per_minute == 8
+	assert config.request_body_max_bytes == 9
+	assert config.warnings == []
+
+
+def test_load_safety_config_warns_and_uses_defaults_for_invalid_values(monkeypatch):
+	monkeypatch.setenv("MEMORIES_RATE_LIMITING_ENABLED", "maybe")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_READS_PER_MINUTE", "0")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_WRITES_PER_MINUTE", "-1")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_BATCH_PER_MINUTE", "ten")
+	monkeypatch.setenv("MEMORIES_RATE_LIMIT_MCP_PER_MINUTE", "")
+	monkeypatch.setenv("MEMORIES_REQUEST_BODY_MAX_BYTES", "0")
+
+	config = load_safety_config()
+
+	assert config.rate_limiting_enabled is DEFAULT_RATE_LIMITING_ENABLED
+	assert config.rate_limit_reads_per_minute == DEFAULT_RATE_LIMIT_READS_PER_MINUTE
+	assert config.rate_limit_writes_per_minute == DEFAULT_RATE_LIMIT_WRITES_PER_MINUTE
+	assert config.rate_limit_batch_per_minute == DEFAULT_RATE_LIMIT_BATCH_PER_MINUTE
+	assert config.rate_limit_mcp_per_minute == DEFAULT_RATE_LIMIT_MCP_PER_MINUTE
+	assert config.request_body_max_bytes == DEFAULT_REQUEST_BODY_MAX_BYTES
+	assert len(config.warnings) == 6

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -3,6 +3,10 @@ from pydantic import ValidationError
 
 from app.schemas import (
 	DEFAULT_PAGE_LIMIT,
+	MAX_MEMORY_CONTENT_CHARS,
+	MAX_MEMORY_TAG_CHARS,
+	MAX_MEMORY_TAGS,
+	MAX_TEXT_FILTER_CHARS,
 	Memory,
 	MemoryCreate,
 	MemoryListQuery,
@@ -26,9 +30,28 @@ def test_memory_create_rejects_whitespace_only_content():
 	assert "content cannot be empty" in str(error.value)
 
 
+def test_memory_create_rejects_content_over_character_limit():
+	with pytest.raises(ValidationError) as error:
+		MemoryCreate(content="x" * (MAX_MEMORY_CONTENT_CHARS + 1), tags=["note"])
+
+	assert f"content cannot exceed {MAX_MEMORY_CONTENT_CHARS} characters" in str(error.value)
+
+
 def test_validate_tags_value_rejects_blank_tag():
 	with pytest.raises(ValueError, match="tags cannot contain empty strings"):
 		validate_tags_value(["valid", "   "])
+
+
+def test_validate_tags_value_rejects_too_many_tags():
+	with pytest.raises(
+		ValueError, match=f"tags cannot contain more than {MAX_MEMORY_TAGS} entries"
+	):
+		validate_tags_value([f"tag-{index}" for index in range(MAX_MEMORY_TAGS + 1)])
+
+
+def test_validate_tags_value_rejects_tag_over_character_limit():
+	with pytest.raises(ValueError, match=f"tags cannot exceed {MAX_MEMORY_TAG_CHARS} characters"):
+		validate_tags_value(["x" * (MAX_MEMORY_TAG_CHARS + 1)])
 
 
 def test_memory_update_allows_partial_payload():
@@ -43,6 +66,18 @@ def test_memory_update_rejects_extra_fields():
 		MemoryUpdate(status="active", version=2)
 
 	assert "Extra inputs are not permitted" in str(error.value)
+
+
+def test_memory_update_rejects_content_and_tags_over_limits():
+	with pytest.raises(ValidationError) as error:
+		MemoryUpdate(
+			content="x" * (MAX_MEMORY_CONTENT_CHARS + 1),
+			tags=["x" * (MAX_MEMORY_TAG_CHARS + 1)],
+		)
+
+	message = str(error.value)
+	assert f"content cannot exceed {MAX_MEMORY_CONTENT_CHARS} characters" in message
+	assert f"tags cannot exceed {MAX_MEMORY_TAG_CHARS} characters" in message
 
 
 def test_memory_list_query_applies_defaults():
@@ -94,6 +129,13 @@ def test_memory_list_query_rejects_blank_tag_or_query():
 		MemoryListQuery(tag="   ", q=" ")
 
 	assert "filter cannot be empty" in str(error.value)
+
+
+def test_memory_list_query_rejects_text_filters_over_character_limit():
+	with pytest.raises(ValidationError) as error:
+		MemoryListQuery(tag="x" * (MAX_TEXT_FILTER_CHARS + 1), q="y" * (MAX_TEXT_FILTER_CHARS + 1))
+
+	assert f"filter cannot exceed {MAX_TEXT_FILTER_CHARS} characters" in str(error.value)
 
 
 def test_memory_list_response_requires_non_negative_counts():


### PR DESCRIPTION
## What

- Added process-local fixed-window rate limiting for REST reads, REST writes, batch creation, and MCP HTTP traffic.
- Enforced schema/API limits for memory content, tags, text filters, and batch creation.
- Added `Content-Length` based request body rejection for REST and MCP HTTP requests.
- Added environment-driven local safety settings and app factory state.
- Documented defaults, environment variables, `X-Client-Id`, and local-only safety limitations.

## Why

- Protects the local single-user Memories API from runaway agents, oversized payloads, and accidental request floods.
- Keeps read traffic protected because reads refresh `last_accessed_at` and are not purely read-only.
- Preserves the current local-only unauthenticated security model while making accidental local misuse less costly.

## How

- Added typed safety config loading with conservative defaults and warnings for invalid env values.
- Stored limiter/config state on each FastAPI app instance created by `create_app()`.
- Added a small request-limit helper module for body checks, bucket classification, client identity, and fixed 60-second windows.
- Kept validation at the shared Pydantic schema/API boundary so REST and MCP share the same field limits.

## Test Steps

- `ruff format .`
- `ruff check .`
- `pytest`
- `pre-commit run --all-files`

## Other Notes

- Request body-size enforcement is intentionally based on `Content-Length`; oversized chunked or missing-length bodies are not fully covered in this branch.
- Rate limiting is in-memory and process-local, so multiple worker processes would each have independent windows.
- `X-Client-Id` is local client metadata, not authentication.
