### PR TITLE
harden sqlite runtime initialization

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,11 +1,15 @@
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
+from threading import Lock
 
 from app.config import get_database_file_path
 
 SQLITE_BUSY_TIMEOUT_SECONDS = 5.0
 SQLITE_BUSY_TIMEOUT_MS = 5000
+_INITIALIZED_DATABASE_FILES: set[Path] = set()
+_INITIALIZED_DATABASE_FILES_LOCK = Lock()
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS memories (
@@ -34,29 +38,53 @@ INDEX_SQL = [
 ]
 
 
-def _connect_database() -> sqlite3.Connection:
+def _database_key(database_file: Path) -> Path:
+	return database_file.expanduser().resolve()
+
+
+def _connect_database(database_file: Path) -> sqlite3.Connection:
 	connection = sqlite3.connect(
-		get_database_file_path(),
+		database_file,
 		timeout=SQLITE_BUSY_TIMEOUT_SECONDS,
 	)
 	connection.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
 	return connection
 
 
-def init_db() -> None:
-	database_file = get_database_file_path()
+def _initialize_database(database_file: Path) -> None:
 	database_file.parent.mkdir(parents=True, exist_ok=True)
-	with _connect_database() as connection:
+	with _connect_database(database_file) as connection:
 		connection.execute(SCHEMA_SQL)
 		for index_sql in INDEX_SQL:
 			connection.execute(index_sql)
 		connection.commit()
 
 
+def init_db() -> None:
+	database_file = get_database_file_path()
+	database_key = _database_key(database_file)
+	with _INITIALIZED_DATABASE_FILES_LOCK:
+		_initialize_database(database_file)
+		_INITIALIZED_DATABASE_FILES.add(database_key)
+
+
+def _ensure_db_initialized(database_file: Path) -> None:
+	database_key = _database_key(database_file)
+	if database_key in _INITIALIZED_DATABASE_FILES and database_file.exists():
+		return
+
+	with _INITIALIZED_DATABASE_FILES_LOCK:
+		if database_key in _INITIALIZED_DATABASE_FILES and database_file.exists():
+			return
+		_initialize_database(database_file)
+		_INITIALIZED_DATABASE_FILES.add(database_key)
+
+
 @contextmanager
 def get_connection() -> Iterator[sqlite3.Connection]:
-	init_db()
-	connection = _connect_database()
+	database_file = get_database_file_path()
+	_ensure_db_initialized(database_file)
+	connection = _connect_database(database_file)
 	connection.row_factory = sqlite3.Row
 	try:
 		yield connection

--- a/app/db.py
+++ b/app/db.py
@@ -4,6 +4,9 @@ from contextlib import contextmanager
 
 from app.config import get_database_file_path
 
+SQLITE_BUSY_TIMEOUT_SECONDS = 5.0
+SQLITE_BUSY_TIMEOUT_MS = 5000
+
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS memories (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -18,19 +21,42 @@ CREATE TABLE IF NOT EXISTS memories (
 )
 """
 
+INDEX_SQL = [
+	"""
+	CREATE INDEX IF NOT EXISTS idx_memories_status_memory_type_updated_at_id
+	ON memories (status, memory_type, updated_at DESC, id DESC)
+	""",
+	"CREATE INDEX IF NOT EXISTS idx_memories_status ON memories (status)",
+	"CREATE INDEX IF NOT EXISTS idx_memories_memory_type ON memories (memory_type)",
+	"CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories (created_at)",
+	"CREATE INDEX IF NOT EXISTS idx_memories_updated_at ON memories (updated_at)",
+	"CREATE INDEX IF NOT EXISTS idx_memories_last_accessed_at ON memories (last_accessed_at)",
+]
+
+
+def _connect_database() -> sqlite3.Connection:
+	connection = sqlite3.connect(
+		get_database_file_path(),
+		timeout=SQLITE_BUSY_TIMEOUT_SECONDS,
+	)
+	connection.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
+	return connection
+
 
 def init_db() -> None:
 	database_file = get_database_file_path()
 	database_file.parent.mkdir(parents=True, exist_ok=True)
-	with sqlite3.connect(database_file) as connection:
+	with _connect_database() as connection:
 		connection.execute(SCHEMA_SQL)
+		for index_sql in INDEX_SQL:
+			connection.execute(index_sql)
 		connection.commit()
 
 
 @contextmanager
 def get_connection() -> Iterator[sqlite3.Connection]:
 	init_db()
-	connection = sqlite3.connect(get_database_file_path())
+	connection = _connect_database()
 	connection.row_factory = sqlite3.Row
 	try:
 		yield connection

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 
 from app.config import load_browser_client_config, load_safety_config
+from app.db import init_db
 from app.mcp_server import mcp
 from app.request_limits import (
 	FixedWindowRateLimiter,
@@ -86,6 +87,8 @@ def create_app() -> FastAPI:
 			logger.warning(warning_message)
 		for warning_message in safety_config.warnings:
 			logger.warning(warning_message)
+
+		init_db()
 
 		async with mcp.session_manager.run():
 			yield

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.prompts.base import AssistantMessage
 
+from app.db import init_db
 from app.schemas import MemoryCreate, MemoryListQuery, MemoryListResponse, MemoryUpdate
 from app.storage import (
 	create_memory,
@@ -234,6 +235,7 @@ def inspect_memory(memory_id: int) -> dict:
 
 
 def run_stdio() -> None:
+	init_db()
 	mcp.run()
 
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,0 +1,82 @@
+import sqlite3
+from pathlib import Path
+
+from app.db import SQLITE_BUSY_TIMEOUT_MS, get_connection, init_db
+
+EXPECTED_COLUMNS = [
+	("id", "INTEGER", 0, 1),
+	("content", "TEXT", 1, 0),
+	("tags", "TEXT", 1, 0),
+	("created_at", "TEXT", 1, 0),
+	("updated_at", "TEXT", 1, 0),
+	("last_accessed_at", "TEXT", 0, 0),
+	("memory_type", "TEXT", 1, 0),
+	("status", "TEXT", 1, 0),
+	("version", "INTEGER", 1, 0),
+]
+
+EXPECTED_INDEXES = {
+	"idx_memories_status_memory_type_updated_at_id": [
+		("status", 0),
+		("memory_type", 0),
+		("updated_at", 1),
+		("id", 1),
+	],
+	"idx_memories_status": [("status", 0)],
+	"idx_memories_memory_type": [("memory_type", 0)],
+	"idx_memories_created_at": [("created_at", 0)],
+	"idx_memories_updated_at": [("updated_at", 0)],
+	"idx_memories_last_accessed_at": [("last_accessed_at", 0)],
+}
+
+
+def _read_table_columns(database_file: Path) -> list[tuple[str, str, int, int]]:
+	with sqlite3.connect(database_file) as connection:
+		rows = connection.execute("PRAGMA table_info(memories)").fetchall()
+
+	return [(row[1], row[2], row[3], row[5]) for row in rows]
+
+
+def _read_index_columns(database_file: Path, index_name: str) -> list[tuple[str, int]]:
+	with sqlite3.connect(database_file) as connection:
+		rows = connection.execute(f"PRAGMA index_xinfo({index_name})").fetchall()
+
+	return [(row[2], row[3]) for row in rows if row[5]]
+
+
+def test_init_db_creates_memories_table_and_expected_indexes(data_file):
+	init_db()
+
+	assert _read_table_columns(data_file) == EXPECTED_COLUMNS
+
+	with sqlite3.connect(data_file) as connection:
+		index_names = {row[1] for row in connection.execute("PRAGMA index_list(memories)")}
+
+	assert EXPECTED_INDEXES.keys() <= index_names
+	for index_name, expected_columns in EXPECTED_INDEXES.items():
+		assert _read_index_columns(data_file, index_name) == expected_columns
+
+
+def test_get_connection_sets_busy_timeout():
+	with get_connection() as connection:
+		busy_timeout = connection.execute("PRAGMA busy_timeout").fetchone()[0]
+
+	assert busy_timeout == SQLITE_BUSY_TIMEOUT_MS
+
+
+def test_get_connection_initializes_each_database_file_path(monkeypatch, tmp_path):
+	first_database = tmp_path / "first.db"
+	second_database = tmp_path / "second.db"
+
+	monkeypatch.setenv("MEMORIES_DB_FILE", str(first_database))
+	with get_connection() as connection:
+		first_count = connection.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+
+	monkeypatch.setenv("MEMORIES_DB_FILE", str(second_database))
+	with get_connection() as connection:
+		second_count = connection.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+
+	assert first_count == 0
+	assert second_count == 0
+	assert _read_table_columns(first_database) == EXPECTED_COLUMNS
+	assert _read_table_columns(second_database) == EXPECTED_COLUMNS


### PR DESCRIPTION
## What

- Added idempotent SQLite indexes for status, memory type, timestamp sorts, and the active memory-type bootstrap query shape.
- Set a 5-second SQLite busy timeout on runtime and initialization connections.
- Refactored FastAPI lifespan startup and MCP stdio startup to initialize SQLite explicitly while keeping a path-aware fallback in `get_connection()`.
- Added DB regression tests for schema/index creation, busy timeout configuration, and same-process `MEMORIES_DB_FILE` changes.

## Why

- Makes normal local multi-client use more predictable without changing the public REST or MCP API contract.
- Avoids repeated schema setup on the hot connection path after startup initialization.
- Preserves direct script/test safety when the database path changes in the same Python process.

## How

- Used `CREATE INDEX IF NOT EXISTS` so schema setup remains idempotent.
- Kept WAL untouched and limited the runtime hardening to indexes, busy timeout, and initialization placement.
- Tracked initialized database files by resolved path so new `MEMORIES_DB_FILE` values still bootstrap their schema.

## Test Steps

- [x] `ruff format .` - passed
- [x] `ruff check .` - passed
- [x] `pytest` - passed
- [x] `pre-commit run --all-files` - passed
