### PR TITLE
Add operational API basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Interactive docs are available at http://127.0.0.1:8000/docs
 The running app exposes:
 
 - REST API at `http://127.0.0.1:8000/memories`
+- Health endpoint at `http://127.0.0.1:8000/health`
+- Readiness endpoint at `http://127.0.0.1:8000/ready`
 - MCP streamable HTTP endpoint at `http://127.0.0.1:8000/mcp`
 - MCP stdio entrypoint with `python -m app.mcp_server`
 
@@ -149,6 +151,41 @@ HTTP and MCP expose one deterministic retrieval contract.
 
 That keeps retrieval easy to test and consistent across HTTP and MCP.
 
+### Operational endpoints and request IDs
+
+The API includes lightweight local operational endpoints:
+
+- `GET /health` returns `{"status": "ok"}` as a side-effect-free ping. It does not read memories or refresh `last_accessed_at`.
+- `GET /ready` checks that SQLite is reachable and the `memories` table exists. It may initialize the local DB/schema on first run, but it does not create, read, or update memory rows.
+
+Readiness responses include non-sensitive check status only. A ready response returns:
+
+```json
+{
+	"status": "ready",
+	"checks": {
+		"database": "ok",
+		"memories_table": "ok"
+	}
+}
+```
+
+If a readiness check fails, the endpoint returns `503` with `status` set to `not_ready` and failed checks marked as `failed`. Responses do not include local database paths, raw exception text, or environment-derived file locations.
+
+Every HTTP response includes `X-Request-Id`, including REST responses, MCP streamable HTTP responses, and middleware-generated rejections such as `413`, `429`, and MCP-origin `403`. If a request sends `X-Request-Id` and it matches `^[A-Za-z0-9._:-]{1,128}$`, the server echoes it. Missing or invalid values are replaced with a server-generated UUID.
+
+The app emits one JSON request log record per HTTP request. Normal REST and MCP HTTP requests are logged at `INFO`; `/health` and `/ready` are logged at `DEBUG` to keep probe traffic quieter. Request log records contain only:
+
+```json
+{
+	"method": "GET",
+	"path": "/memories",
+	"status": 200,
+	"duration_ms": 1.23,
+	"request_id": "example-request-id"
+}
+```
+
 ### Local safety limits
 
 The HTTP API and MCP streamable HTTP endpoint include conservative local safety limits by default. These are intended to protect a single-user local service from runaway agents, oversized payloads, and accidental request floods. They are not a substitute for authentication or transport security.
@@ -173,6 +210,8 @@ Runtime limits are configured with environment variables:
 | `MEMORIES_REQUEST_BODY_MAX_BYTES` | `1048576` | Applies to `POST` and `PATCH` REST/MCP HTTP requests with `Content-Length`. |
 
 Rate limiting uses a fixed 60-second in-memory window per process. Clients are identified by a trimmed `X-Client-Id` header, capped at 128 characters, when present; otherwise the client IP is used. A limited request returns `429` with `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers.
+
+`/health` and `/ready` are exempt from normal rate limiting.
 
 Request body-size enforcement uses the `Content-Length` header and returns `413` with `X-Request-Body-Limit`. This covers normal local agent clients but does not fully cover oversized chunked or missing-length bodies.
 

--- a/app/db.py
+++ b/app/db.py
@@ -68,6 +68,31 @@ def init_db() -> None:
 		_INITIALIZED_DATABASE_FILES.add(database_key)
 
 
+def check_database_readiness() -> dict[str, str]:
+	checks = {
+		"database": "failed",
+		"memories_table": "failed",
+	}
+
+	try:
+		with get_connection() as connection:
+			connection.execute("SELECT 1").fetchone()
+			checks["database"] = "ok"
+			table = connection.execute(
+				"""
+				SELECT 1
+				FROM sqlite_master
+				WHERE type = 'table' AND name = 'memories'
+				"""
+			).fetchone()
+			if table is not None:
+				checks["memories_table"] = "ok"
+	except (OSError, sqlite3.Error):
+		return checks
+
+	return checks
+
+
 def _ensure_db_initialized(database_file: Path) -> None:
 	database_key = _database_key(database_file)
 	if database_key in _INITIALIZED_DATABASE_FILES and database_file.exists():

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from contextlib import asynccontextmanager
 from typing import Annotated
 
@@ -18,6 +19,7 @@ from app.request_limits import (
 	reject_request_body_if_too_large,
 	reject_request_if_rate_limited,
 )
+from app.request_logging import current_duration_ms, log_http_request
 from app.schemas import (
 	DEFAULT_PAGE_LIMIT,
 	MAX_BATCH_CREATE_MEMORIES,
@@ -123,15 +125,26 @@ def create_app() -> FastAPI:
 
 	@application.middleware("http")
 	async def enforce_request_safety(request: Request, call_next):
+		start_time = time.perf_counter()
 		request_id = resolve_request_id(request.headers.get(REQUEST_ID_HEADER))
 		request.state.request_id = request_id
+
+		def complete_response(response):
+			log_http_request(
+				logger,
+				request,
+				status_code=response.status_code,
+				duration_ms=current_duration_ms(start_time),
+				request_id=request_id,
+			)
+			return set_request_id_header(response, request_id)
 
 		body_limit_response = reject_request_body_if_too_large(
 			request,
 			safety_config.request_body_max_bytes,
 		)
 		if body_limit_response is not None:
-			return set_request_id_header(body_limit_response, request_id)
+			return complete_response(body_limit_response)
 
 		rate_limit_response = reject_request_if_rate_limited(
 			request,
@@ -139,18 +152,28 @@ def create_app() -> FastAPI:
 			safety_config,
 		)
 		if rate_limit_response is not None:
-			return set_request_id_header(rate_limit_response, request_id)
+			return complete_response(rate_limit_response)
 
 		origin = request.headers.get("origin")
 		if request.url.path.startswith("/mcp") and origin is not None:
 			if origin not in browser_client_config.allowed_origins:
-				return set_request_id_header(
+				return complete_response(
 					JSONResponse(status_code=403, content={"detail": "Origin not allowed"}),
-					request_id,
 				)
 
-		response = await call_next(request)
-		return set_request_id_header(response, request_id)
+		try:
+			response = await call_next(request)
+		except Exception:
+			log_http_request(
+				logger,
+				request,
+				status_code=500,
+				duration_ms=current_duration_ms(start_time),
+				request_id=request_id,
+			)
+			raise
+
+		return complete_response(response)
 
 	@application.get("/health")
 	def health_check() -> dict[str, str]:

--- a/app/main.py
+++ b/app/main.py
@@ -100,6 +100,19 @@ def create_app() -> FastAPI:
 	application.state.browser_client_config = browser_client_config
 	application.state.safety_config = safety_config
 	application.state.rate_limiter = FixedWindowRateLimiter()
+
+	@application.exception_handler(Exception)
+	async def unhandled_exception_response(request: Request, _error: Exception) -> JSONResponse:
+		request_id = getattr(
+			request.state,
+			"request_id",
+			resolve_request_id(request.headers.get(REQUEST_ID_HEADER)),
+		)
+		return set_request_id_header(
+			JSONResponse(status_code=500, content={"detail": "Internal Server Error"}),
+			request_id,
+		)
+
 	application.add_middleware(
 		CORSMiddleware,
 		allow_origins=browser_client_config.allowed_origins,

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 
 from app.config import load_browser_client_config, load_safety_config
-from app.db import init_db
+from app.db import check_database_readiness, init_db
 from app.mcp_server import mcp
 from app.request_limits import (
 	FixedWindowRateLimiter,
@@ -141,6 +141,21 @@ def create_app() -> FastAPI:
 				return JSONResponse(status_code=403, content={"detail": "Origin not allowed"})
 
 		return await call_next(request)
+
+	@application.get("/health")
+	def health_check() -> dict[str, str]:
+		return {"status": "ok"}
+
+	@application.get("/ready")
+	def readiness_check():
+		checks = check_database_readiness()
+		if all(status == "ok" for status in checks.values()):
+			return {"status": "ready", "checks": checks}
+
+		return JSONResponse(
+			status_code=503,
+			content={"status": "not_ready", "checks": checks},
+		)
 
 	@application.post("/memories")
 	def post_memory(memory: MemoryCreate) -> Memory:

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from app.config import load_browser_client_config, load_safety_config
 from app.db import check_database_readiness, init_db
 from app.mcp_server import mcp
+from app.request_context import REQUEST_ID_HEADER, resolve_request_id, set_request_id_header
 from app.request_limits import (
 	FixedWindowRateLimiter,
 	reject_request_body_if_too_large,
@@ -107,6 +108,7 @@ def create_app() -> FastAPI:
 			"MCP-Protocol-Version",
 			"Mcp-Session-Id",
 			"X-Client-Id",
+			REQUEST_ID_HEADER,
 		],
 		expose_headers=[
 			"Mcp-Session-Id",
@@ -115,17 +117,21 @@ def create_app() -> FastAPI:
 			"X-RateLimit-Remaining",
 			"X-RateLimit-Reset",
 			"X-Request-Body-Limit",
+			REQUEST_ID_HEADER,
 		],
 	)
 
 	@application.middleware("http")
 	async def enforce_request_safety(request: Request, call_next):
+		request_id = resolve_request_id(request.headers.get(REQUEST_ID_HEADER))
+		request.state.request_id = request_id
+
 		body_limit_response = reject_request_body_if_too_large(
 			request,
 			safety_config.request_body_max_bytes,
 		)
 		if body_limit_response is not None:
-			return body_limit_response
+			return set_request_id_header(body_limit_response, request_id)
 
 		rate_limit_response = reject_request_if_rate_limited(
 			request,
@@ -133,14 +139,18 @@ def create_app() -> FastAPI:
 			safety_config,
 		)
 		if rate_limit_response is not None:
-			return rate_limit_response
+			return set_request_id_header(rate_limit_response, request_id)
 
 		origin = request.headers.get("origin")
 		if request.url.path.startswith("/mcp") and origin is not None:
 			if origin not in browser_client_config.allowed_origins:
-				return JSONResponse(status_code=403, content={"detail": "Origin not allowed"})
+				return set_request_id_header(
+					JSONResponse(status_code=403, content={"detail": "Origin not allowed"}),
+					request_id,
+				)
 
-		return await call_next(request)
+		response = await call_next(request)
+		return set_request_id_header(response, request_id)
 
 	@application.get("/health")
 	def health_check() -> dict[str, str]:

--- a/app/request_context.py
+++ b/app/request_context.py
@@ -1,0 +1,19 @@
+import re
+from uuid import uuid4
+
+from starlette.responses import Response
+
+REQUEST_ID_HEADER = "X-Request-Id"
+REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+
+def resolve_request_id(header_value: str | None) -> str:
+	if header_value is not None and REQUEST_ID_PATTERN.fullmatch(header_value):
+		return header_value
+
+	return str(uuid4())
+
+
+def set_request_id_header(response: Response, request_id: str) -> Response:
+	response.headers[REQUEST_ID_HEADER] = request_id
+	return response

--- a/app/request_logging.py
+++ b/app/request_logging.py
@@ -1,0 +1,30 @@
+import json
+import logging
+import time
+
+from starlette.requests import Request
+
+OPERATIONAL_PATHS = {"/health", "/ready"}
+
+
+def current_duration_ms(start_time: float) -> float:
+	return round((time.perf_counter() - start_time) * 1000, 3)
+
+
+def log_http_request(
+	logger: logging.Logger,
+	request: Request,
+	*,
+	status_code: int,
+	duration_ms: float,
+	request_id: str,
+) -> None:
+	payload = {
+		"method": request.method,
+		"path": request.url.path,
+		"status": status_code,
+		"duration_ms": duration_ms,
+		"request_id": request_id,
+	}
+	level = logging.DEBUG if request.url.path in OPERATIONAL_PATHS else logging.INFO
+	logger.log(level, json.dumps(payload, separators=(",", ":")))

--- a/tests/contract/test_http_contract.py
+++ b/tests/contract/test_http_contract.py
@@ -1,3 +1,4 @@
+import sqlite3
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -14,6 +15,41 @@ def assert_rate_limited(response, limit: int):
 	assert response.headers["X-RateLimit-Limit"] == str(limit)
 	assert response.headers["X-RateLimit-Remaining"] == "0"
 	assert response.headers["X-RateLimit-Reset"].isdigit()
+
+
+def test_health_check_returns_ping_without_initializing_database(
+	client: TestClient, data_file: Path
+):
+	response = client.get("/health")
+
+	assert response.status_code == 200
+	assert response.json() == {"status": "ok"}
+	assert not data_file.exists()
+
+
+def test_readiness_check_initializes_schema_without_memory_rows(
+	client: TestClient, data_file: Path
+):
+	response = client.get("/ready")
+
+	assert response.status_code == 200
+	assert response.json() == {
+		"status": "ready",
+		"checks": {
+			"database": "ok",
+			"memories_table": "ok",
+		},
+	}
+	with sqlite3.connect(data_file) as connection:
+		table = connection.execute(
+			"""
+			SELECT 1
+			FROM sqlite_master
+			WHERE type = 'table' AND name = 'memories'
+			"""
+		).fetchone()
+	assert table is not None
+	assert read_database(data_file) == []
 
 
 def test_post_memory_response_matches_public_contract(

--- a/tests/contract/test_http_contract.py
+++ b/tests/contract/test_http_contract.py
@@ -1,3 +1,5 @@
+import json
+import logging
 import sqlite3
 from pathlib import Path
 from uuid import UUID
@@ -7,6 +9,8 @@ from helpers.database_helpers import read_database
 
 from app import main as app_main
 from app import storage
+
+REQUEST_LOG_FIELDS = {"method", "path", "status", "duration_ms", "request_id"}
 
 
 def assert_rate_limited(response, limit: int):
@@ -20,6 +24,20 @@ def assert_rate_limited(response, limit: int):
 
 def assert_uuid(value: str):
 	UUID(value)
+
+
+def request_log_payloads(caplog):
+	payloads = []
+	for record in caplog.records:
+		if record.name != "app.main":
+			continue
+		try:
+			payload = json.loads(record.message)
+		except json.JSONDecodeError:
+			continue
+		if set(payload) == REQUEST_LOG_FIELDS:
+			payloads.append((record, payload))
+	return payloads
 
 
 def test_health_check_returns_ping_without_initializing_database(
@@ -72,6 +90,40 @@ def test_request_id_replaces_invalid_client_header(client: TestClient):
 	assert_uuid(response.headers["X-Request-Id"])
 
 
+def test_memory_request_logs_json_record_at_info(client: TestClient, caplog):
+	caplog.set_level(logging.INFO, logger="app.main")
+
+	response = client.get("/memories", headers={"X-Request-Id": "list-request"})
+
+	assert response.status_code == 200
+	request_logs = request_log_payloads(caplog)
+	assert len(request_logs) == 1
+	record, payload = request_logs[0]
+	assert record.levelno == logging.INFO
+	assert payload["method"] == "GET"
+	assert payload["path"] == "/memories"
+	assert payload["status"] == 200
+	assert isinstance(payload["duration_ms"], float)
+	assert payload["request_id"] == "list-request"
+
+
+def test_health_check_logs_light_json_record_at_debug(client: TestClient, caplog):
+	caplog.set_level(logging.DEBUG, logger="app.main")
+
+	response = client.get("/health", headers={"X-Request-Id": "probe-request"})
+
+	assert response.status_code == 200
+	request_logs = request_log_payloads(caplog)
+	assert len(request_logs) == 1
+	record, payload = request_logs[0]
+	assert record.levelno == logging.DEBUG
+	assert payload["method"] == "GET"
+	assert payload["path"] == "/health"
+	assert payload["status"] == 200
+	assert isinstance(payload["duration_ms"], float)
+	assert payload["request_id"] == "probe-request"
+
+
 def test_post_memory_response_matches_public_contract(
 	client: TestClient, data_file: Path, monkeypatch
 ):
@@ -106,20 +158,31 @@ def test_post_memory_response_matches_public_contract(
 	assert read_database(data_file) == [body]
 
 
-def test_post_memory_rejects_oversized_body_before_json_parsing(monkeypatch, data_file: Path):
+def test_post_memory_rejects_oversized_body_before_json_parsing(
+	monkeypatch, data_file: Path, caplog
+):
 	monkeypatch.setenv("MEMORIES_REQUEST_BODY_MAX_BYTES", "10")
+	caplog.set_level(logging.INFO, logger="app.main")
 	test_client = TestClient(app_main.create_app())
 
 	response = test_client.post(
 		"/memories",
 		content="x" * 11,
-		headers={"Content-Type": "application/json"},
+		headers={"Content-Type": "application/json", "X-Request-Id": "oversized-request"},
 	)
 
 	assert response.status_code == 413
 	assert response.json() == {"detail": "Request body too large"}
 	assert response.headers["X-Request-Body-Limit"] == "10"
-	assert_uuid(response.headers["X-Request-Id"])
+	assert response.headers["X-Request-Id"] == "oversized-request"
+	request_logs = request_log_payloads(caplog)
+	assert len(request_logs) == 1
+	record, payload = request_logs[0]
+	assert record.levelno == logging.INFO
+	assert payload["method"] == "POST"
+	assert payload["path"] == "/memories"
+	assert payload["status"] == 413
+	assert payload["request_id"] == "oversized-request"
 	assert read_database(data_file) == []
 
 

--- a/tests/contract/test_http_contract.py
+++ b/tests/contract/test_http_contract.py
@@ -1,5 +1,6 @@
 import sqlite3
 from pathlib import Path
+from uuid import UUID
 
 from fastapi.testclient import TestClient
 from helpers.database_helpers import read_database
@@ -15,6 +16,10 @@ def assert_rate_limited(response, limit: int):
 	assert response.headers["X-RateLimit-Limit"] == str(limit)
 	assert response.headers["X-RateLimit-Remaining"] == "0"
 	assert response.headers["X-RateLimit-Reset"].isdigit()
+
+
+def assert_uuid(value: str):
+	UUID(value)
 
 
 def test_health_check_returns_ping_without_initializing_database(
@@ -50,6 +55,21 @@ def test_readiness_check_initializes_schema_without_memory_rows(
 		).fetchone()
 	assert table is not None
 	assert read_database(data_file) == []
+
+
+def test_request_id_echoes_valid_client_header(client: TestClient):
+	response = client.get("/health", headers={"X-Request-Id": "agent.123:request-456"})
+
+	assert response.status_code == 200
+	assert response.headers["X-Request-Id"] == "agent.123:request-456"
+
+
+def test_request_id_replaces_invalid_client_header(client: TestClient):
+	response = client.get("/health", headers={"X-Request-Id": "bad request id"})
+
+	assert response.status_code == 200
+	assert response.headers["X-Request-Id"] != "bad request id"
+	assert_uuid(response.headers["X-Request-Id"])
 
 
 def test_post_memory_response_matches_public_contract(
@@ -99,6 +119,7 @@ def test_post_memory_rejects_oversized_body_before_json_parsing(monkeypatch, dat
 	assert response.status_code == 413
 	assert response.json() == {"detail": "Request body too large"}
 	assert response.headers["X-Request-Body-Limit"] == "10"
+	assert_uuid(response.headers["X-Request-Id"])
 	assert read_database(data_file) == []
 
 
@@ -125,6 +146,7 @@ def test_post_memory_rate_limit_uses_client_id_identity(monkeypatch, data_file: 
 	assert first_response.status_code == 200
 	assert "X-RateLimit-Limit" not in first_response.headers
 	assert_rate_limited(second_response, 1)
+	assert_uuid(second_response.headers["X-Request-Id"])
 	assert other_client_response.status_code == 200
 	assert len(read_database(data_file)) == 2
 

--- a/tests/contract/test_http_contract.py
+++ b/tests/contract/test_http_contract.py
@@ -107,6 +107,32 @@ def test_memory_request_logs_json_record_at_info(client: TestClient, caplog):
 	assert payload["request_id"] == "list-request"
 
 
+def test_unhandled_error_response_includes_request_id(caplog):
+	caplog.set_level(logging.INFO, logger="app.main")
+	test_client = TestClient(app_main.create_app(), raise_server_exceptions=False)
+
+	@test_client.app.get("/raise-unhandled-error")
+	def raise_unhandled_error():
+		raise RuntimeError("contract regression")
+
+	response = test_client.get(
+		"/raise-unhandled-error",
+		headers={"X-Request-Id": "error-request"},
+	)
+
+	assert response.status_code == 500
+	assert response.json() == {"detail": "Internal Server Error"}
+	assert response.headers["X-Request-Id"] == "error-request"
+	request_logs = request_log_payloads(caplog)
+	assert len(request_logs) == 1
+	record, payload = request_logs[0]
+	assert record.levelno == logging.INFO
+	assert payload["method"] == "GET"
+	assert payload["path"] == "/raise-unhandled-error"
+	assert payload["status"] == 500
+	assert payload["request_id"] == "error-request"
+
+
 def test_health_check_logs_light_json_record_at_debug(client: TestClient, caplog):
 	caplog.set_level(logging.DEBUG, logger="app.main")
 

--- a/tests/contract/test_mcp_http_transport.py
+++ b/tests/contract/test_mcp_http_transport.py
@@ -1,12 +1,17 @@
 import importlib
 import json
 from pathlib import Path
+from uuid import UUID
 
 from fastapi.testclient import TestClient
 
 import app.main as main_module
 import app.mcp_server as mcp_server_module
 from app import config as config_module
+
+
+def assert_uuid(value: str):
+	UUID(value)
 
 
 def build_client_with_fresh_mcp():
@@ -44,6 +49,7 @@ def test_mcp_http_rejects_browser_requests_when_no_local_allowlist_exists(
 
 	assert response.status_code == 403
 	assert response.json() == {"detail": "Origin not allowed"}
+	assert_uuid(response.headers["X-Request-Id"])
 
 
 def test_mcp_http_allows_configured_browser_origin(monkeypatch, tmp_path: Path):
@@ -63,6 +69,7 @@ def test_mcp_http_allows_configured_browser_origin(monkeypatch, tmp_path: Path):
 	expose_headers = response.headers["access-control-expose-headers"]
 	assert "X-RateLimit-Limit" in expose_headers
 	assert "X-Request-Body-Limit" in expose_headers
+	assert "X-Request-Id" in expose_headers
 
 
 def test_mcp_http_rejects_oversized_body_before_transport_parsing(monkeypatch):
@@ -78,6 +85,7 @@ def test_mcp_http_rejects_oversized_body_before_transport_parsing(monkeypatch):
 	assert response.status_code == 413
 	assert response.json() == {"detail": "Request body too large"}
 	assert response.headers["X-Request-Body-Limit"] == "10"
+	assert_uuid(response.headers["X-Request-Id"])
 
 
 def test_mcp_http_rate_limit_returns_stable_429(monkeypatch):
@@ -94,6 +102,7 @@ def test_mcp_http_rate_limit_returns_stable_429(monkeypatch):
 	assert second_response.headers["X-RateLimit-Limit"] == "1"
 	assert second_response.headers["X-RateLimit-Remaining"] == "0"
 	assert second_response.headers["X-RateLimit-Reset"].isdigit()
+	assert_uuid(second_response.headers["X-Request-Id"])
 
 
 def test_mcp_http_allows_valid_origin_when_another_browser_client_is_invalid(
@@ -128,7 +137,7 @@ def test_mcp_http_allows_mcp_request_headers_for_allowed_origin(monkeypatch, tmp
 			headers={
 				"Origin": "http://localhost:3000",
 				"Access-Control-Request-Method": "POST",
-				"Access-Control-Request-Headers": "MCP-Protocol-Version,Mcp-Session-Id,X-Client-Id",
+				"Access-Control-Request-Headers": "MCP-Protocol-Version,Mcp-Session-Id,X-Client-Id,X-Request-Id",
 			},
 		)
 
@@ -137,3 +146,4 @@ def test_mcp_http_allows_mcp_request_headers_for_allowed_origin(monkeypatch, tmp
 	assert "MCP-Protocol-Version" in response.headers["access-control-allow-headers"]
 	assert "Mcp-Session-Id" in response.headers["access-control-allow-headers"]
 	assert "X-Client-Id" in response.headers["access-control-allow-headers"]
+	assert "X-Request-Id" in response.headers["access-control-allow-headers"]

--- a/tests/contract/test_mcp_http_transport.py
+++ b/tests/contract/test_mcp_http_transport.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+import logging
 from pathlib import Path
 from uuid import UUID
 
@@ -9,9 +10,25 @@ import app.main as main_module
 import app.mcp_server as mcp_server_module
 from app import config as config_module
 
+REQUEST_LOG_FIELDS = {"method", "path", "status", "duration_ms", "request_id"}
+
 
 def assert_uuid(value: str):
 	UUID(value)
+
+
+def request_log_payloads(caplog):
+	payloads = []
+	for record in caplog.records:
+		if record.name != "app.main":
+			continue
+		try:
+			payload = json.loads(record.message)
+		except json.JSONDecodeError:
+			continue
+		if set(payload) == REQUEST_LOG_FIELDS:
+			payloads.append((record, payload))
+	return payloads
 
 
 def build_client_with_fresh_mcp():
@@ -38,18 +55,31 @@ def build_client_without_browser_config(monkeypatch, tmp_path: Path):
 
 
 def test_mcp_http_rejects_browser_requests_when_no_local_allowlist_exists(
-	monkeypatch, tmp_path: Path
+	monkeypatch, tmp_path: Path, caplog
 ):
+	caplog.set_level(logging.INFO, logger="app.main")
+
 	with build_client_without_browser_config(monkeypatch, tmp_path) as client:
 		response = client.post(
 			"/mcp",
-			headers={"Origin": "http://localhost:3000"},
+			headers={
+				"Origin": "http://localhost:3000",
+				"X-Request-Id": "mcp-origin-check",
+			},
 			json={},
 		)
 
 	assert response.status_code == 403
 	assert response.json() == {"detail": "Origin not allowed"}
-	assert_uuid(response.headers["X-Request-Id"])
+	assert response.headers["X-Request-Id"] == "mcp-origin-check"
+	request_logs = request_log_payloads(caplog)
+	assert len(request_logs) == 1
+	record, payload = request_logs[0]
+	assert record.levelno == logging.INFO
+	assert payload["method"] == "POST"
+	assert payload["path"] == "/mcp"
+	assert payload["status"] == 403
+	assert payload["request_id"] == "mcp-origin-check"
 
 
 def test_mcp_http_allows_configured_browser_origin(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## What

- Added side-effect-free `GET /health` and SQLite/table-backed `GET /ready` operational endpoints.
- Added `X-Request-Id` validation, UUID fallback generation, response propagation, and CORS exposure for REST and MCP HTTP.
- Added minimal JSON request logging for REST and MCP HTTP, with `/health` and `/ready` logged at DEBUG.
- Updated README operational documentation.

## Why

- Makes the local Memories API easier to supervise and debug without using memory retrieval endpoints that update `last_accessed_at`.
- Gives REST and MCP HTTP clients a stable request correlation header across normal responses and middleware-generated rejections.
- Adds lightweight observability without changing the local-only security posture or exposing sensitive local paths.

## How

- Added a DB readiness helper that uses normal DB setup and verifies the `memories` table without reading or mutating memory rows.
- Centralized request ID validation in `app/request_context.py` using `^[A-Za-z0-9._:-]{1,128}$` and UUID fallback.
- Added `app/request_logging.py` to emit compact JSON records containing only method, path, status, duration, and request ID.
- Covered REST and mounted MCP HTTP behavior through contract tests.

## Test Steps

- [x] Run `ruff format --check .`
- [x] Run `ruff check .`
- [x] Run `pytest`
- [x] Run `pre-commit run --all-files`
